### PR TITLE
Add generator rule to create rolebinding in new namespaces

### DIFF
--- a/class/appuio-cloud.yml
+++ b/class/appuio-cloud.yml
@@ -8,5 +8,6 @@ parameters:
       - input_paths:
           - appuio-cloud/component/main.jsonnet
           - appuio-cloud/component/namespace-policies.jsonnet
+          - appuio-cloud/component/generated-rolebindings.jsonnet
         input_type: jsonnet
         output_path: appuio-cloud/

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,3 +16,7 @@ parameters:
       openshift: openshift-*
       projectsyn: syn-*
       appuio: appuio-*
+
+    generateDefaultRoleBinding:
+      bindingName: admin
+      clusterRoleName: admin

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -17,6 +17,6 @@ parameters:
       projectsyn: syn-*
       appuio: appuio-*
 
-    generateDefaultRoleBinding:
+    generatedDefaultRoleBindingInNewNamespaces:
       bindingName: admin
       clusterRoleName: admin

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -1,4 +1,9 @@
-local DefaultLabels = {
+local kap = import 'lib/kapitan.libjsonnet';
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.appuio_cloud;
+
+local defaultLabels = {
   metadata+: {
     labels+: {
       'app.kubernetes.io/name': 'appuio-cloud',
@@ -8,6 +13,24 @@ local DefaultLabels = {
   },
 };
 
+local flattenSet(set) = std.flatMap(function(s)
+                                      if std.isArray(set[s]) then set[s] else [ set[s] ],
+                                    std.objectFields(std.prune(set)));
+
+/**
+  * bypassNamespaceRestrictionsSubjects returns an object containing the configured roles and subjects
+  * allowed to bypass restrictions.
+  */
+local bypassNamespaceRestrictionsSubjects() = {
+  local bypass = params.bypassNamespaceRestrictions,
+  clusterRoles+: flattenSet(bypass.clusterRoles),
+  roles+: flattenSet(bypass.roles),
+  subjects+: flattenSet(bypass.subjects),
+};
+
+
 {
-  DefaultLabels: DefaultLabels,
+  DefaultLabels: defaultLabels,
+  FlattenSet: flattenSet,
+  BypassNamespaceRestrictionsSubjects: bypassNamespaceRestrictionsSubjects,
 }

--- a/component/generated-rolebindings.jsonnet
+++ b/component/generated-rolebindings.jsonnet
@@ -35,13 +35,13 @@ local generateDefaultRolebindingInNsPolicy = kyverno.ClusterPolicy('default-role
         generate: {
           kind: 'RoleBinding',
           synchronize: false,
-          name: params.generateDefaultRoleBinding.bindingName,
+          name: params.generatedDefaultRoleBindingInNewNamespaces.bindingName,
           namespace: '{{request.object.metadata.name}}',
           data: {
             roleRef: {
               apiGroup: 'rbac.authorization.k8s.io',
               kind: 'ClusterRole',
-              name: params.generateDefaultRoleBinding.clusterRoleName,
+              name: params.generatedDefaultRoleBindingInNewNamespaces.clusterRoleName,
             },
             subjects: [
               {

--- a/component/generated-rolebindings.jsonnet
+++ b/component/generated-rolebindings.jsonnet
@@ -1,5 +1,10 @@
 local common = import 'common.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
 local kyverno = import 'lib/kyverno.libsonnet';
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.appuio_cloud;
+
 /**
   * This policy will:
   * - Generate a RoleBinding to ClusterRole 'admin' for the organization defined in a label of a namespace.
@@ -30,13 +35,13 @@ local generateDefaultRolebindingInNsPolicy = kyverno.ClusterPolicy('default-role
         generate: {
           kind: 'RoleBinding',
           synchronize: false,
-          name: 'admin',
+          name: params.generateDefaultRoleBinding.bindingName,
           namespace: '{{request.object.metadata.name}}',
           data: {
             roleRef: {
               apiGroup: 'rbac.authorization.k8s.io',
               kind: 'ClusterRole',
-              name: 'admin',
+              name: params.generateDefaultRoleBinding.clusterRoleName,
             },
             subjects: [
               {

--- a/component/generated-rolebindings.jsonnet
+++ b/component/generated-rolebindings.jsonnet
@@ -1,0 +1,57 @@
+local common = import 'common.libsonnet';
+local kyverno = import 'lib/kyverno.libsonnet';
+/**
+  * This policy will:
+  * - Generate a RoleBinding to ClusterRole 'admin' for the organization defined in a label of a namespace.
+  * - Namespaces that do not have the 'appuio.io/organization' label are not affected.
+  * - The RoleBinding is only created upon Namespace creation.
+  * - Also, the RoleBinding is mutable by the user.
+  */
+local generateDefaultRolebindingInNsPolicy = kyverno.ClusterPolicy('default-rolebinding-in-ns') {
+  spec: {
+    rules: [
+      {
+        name: 'default-rolebinding',
+        match: {
+          resources: {
+            kinds: [
+              'Namespace',
+            ],
+            selector: {
+              matchExpressions: [
+                {
+                  key: 'appuio.io/organization',
+                  operator: 'Exists',
+                },
+              ],
+            },
+          },
+        },
+        generate: {
+          kind: 'RoleBinding',
+          synchronize: false,
+          name: 'admin',
+          namespace: '{{request.object.metadata.name}}',
+          data: {
+            roleRef: {
+              apiGroup: 'rbac.authorization.k8s.io',
+              kind: 'ClusterRole',
+              name: 'admin',
+            },
+            subjects: [
+              {
+                kind: 'Group',
+                name: '{{request.object.metadata.labels."appuio.io/organization"}}',
+              },
+            ],
+          },
+        },
+      },
+    ],
+  },
+};
+
+// Define outputs below
+{
+  '10_generate_default_rolebinding_in_ns': generateDefaultRolebindingInNsPolicy + common.DefaultLabels,
+}

--- a/component/namespace-policies.jsonnet
+++ b/component/namespace-policies.jsonnet
@@ -7,22 +7,6 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.appuio_cloud;
 
-local flattenSet(set) = std.flatMap(function(s)
-                                      if std.isArray(set[s]) then set[s] else [ set[s] ],
-                                    std.objectFields(std.prune(set)));
-
-/**
-  * bypassNamespaceRestrictionsSubjects returns an object containing the configured roles and subjects
-  * allowed to bypass restrictions.
-  */
-local bypassNamespaceRestrictionsSubjects() = {
-  local bypass = params.bypassNamespaceRestrictions,
-  clusterRoles+: flattenSet(bypass.clusterRoles),
-  roles+: flattenSet(bypass.roles),
-  subjects+: flattenSet(bypass.subjects),
-};
-
-
 /**
   * appuio-ns-provisioner role allows to create namespaces
   */
@@ -83,7 +67,7 @@ local organizationNamespaces = kyverno.ClusterPolicy('organization-namespaces') 
             ],
           },
         },
-        exclude: bypassNamespaceRestrictionsSubjects(),
+        exclude: common.BypassNamespaceRestrictionsSubjects(),
         validate: {
           message: 'Namespace must have organization',
           pattern: {
@@ -161,10 +145,10 @@ local disallowReservedNamespaces = kyverno.ClusterPolicy('disallow-reserved-name
             kinds: [
               'Namespace',
             ],
-            names: flattenSet(params.reservedNamespaces),
+            names: common.FlattenSet(params.reservedNamespaces),
           },
         },
-        exclude: bypassNamespaceRestrictionsSubjects(),
+        exclude: common.BypassNamespaceRestrictionsSubjects(),
         validate: {
           message: 'Changing or creating reserved namespaces is not allowed.',
           deny: {},

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -74,3 +74,20 @@ subjects:
 ----
 
 `ServiceAccount`, `User` or `Group` (chosen by `kind:`) excluded from all namespace policies.
+
+== `generateDefaultRoleBinding.clusterRoleName`
+
+[horizontal]
+type:: string
+default:: `admin`
+
+The `ClusterRole` name to which the requesting user account gets a new `RoleBinding` to.
+
+== `generateDefaultRoleBinding.bindingName`
+
+[horizontal]
+type:: string
+default:: `admin`
+
+The `metadata.name` of the `RoleBinding` that gets generated in the new `Namespace` created by the user.
+The role binding is only created upon Namespace creation, it doesn't get synchronized.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -75,7 +75,7 @@ subjects:
 
 `ServiceAccount`, `User` or `Group` (chosen by `kind:`) excluded from all namespace policies.
 
-== `generateDefaultRoleBinding.clusterRoleName`
+== `generatedDefaultRoleBindingInNewNamespaces.clusterRoleName`
 
 [horizontal]
 type:: string
@@ -83,7 +83,7 @@ default:: `admin`
 
 The `ClusterRole` name to which the requesting user account gets a new `RoleBinding` to.
 
-== `generateDefaultRoleBinding.bindingName`
+== `generatedDefaultRoleBindingInNewNamespaces.bindingName`
 
 [horizontal]
 type:: string

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -4,7 +4,7 @@ parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-kyverno/v1.0.0/lib/kyverno.libsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-kyverno/v1.1.0/lib/kyverno.libsonnet
         output_path: vendor/lib/kyverno.libsonnet
 
   appuio_cloud:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
@@ -1,0 +1,34 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: appuio-cloud
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud
+    name: default-rolebinding-in-ns
+  name: default-rolebinding-in-ns
+spec:
+  rules:
+    - generate:
+        data:
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: admin
+          subjects:
+            - kind: Group
+              name: '{{request.object.metadata.labels."appuio.io/organization"}}'
+        kind: RoleBinding
+        name: admin
+        namespace: '{{request.object.metadata.name}}'
+        synchronize: false
+      match:
+        resources:
+          kinds:
+            - Namespace
+          selector:
+            matchExpressions:
+              - key: appuio.io/organization
+                operator: Exists
+      name: default-rolebinding


### PR DESCRIPTION
## Summary

* Adds a Kyverno Rule to generate the admin Rolebinding when creating new namespaces for an organization.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
