### PR TITLE
Allow OpenShift to bypass Namespace policies

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,6 +7,8 @@ parameters:
       roles: {}
       clusterRoles:
         cluster-admin: cluster-admin
+        # This is the OpenShift role that syncs namespaces after creation (e.g. add system-relevant labels/annotations from Project)
+        namespace-security-allocation-controller: system:openshift:controller:namespace-security-allocation-controller
       subjects: {}
 
     reservedNamespaces:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
@@ -14,6 +14,7 @@ spec:
     - exclude:
         clusterRoles:
           - cluster-admin
+          - system:openshift:controller:namespace-security-allocation-controller
         roles: []
         subjects:
           - kind: ServiceAccount

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -14,6 +14,7 @@ spec:
     - exclude:
         clusterRoles:
           - cluster-admin
+          - system:openshift:controller:namespace-security-allocation-controller
         roles: []
         subjects:
           - kind: ServiceAccount


### PR DESCRIPTION
We found a lot of errors in Kyverno logs that someone tries to Update namespaces after creation.
With the help of Kyverno verbosity level 6 we found out it's OpenShift itself.

Builds up on #8 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
