### PR TITLE
Inject user's default organization when creating namespace without the organization label

### DIFF
--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -11,6 +11,44 @@ metadata:
 spec:
   background: false
   rules:
+    - context:
+        - apiCall:
+            jmesPath: '@'
+            urlPath: /apis/user.openshift.io/v1/users/{{request.userInfo.username}}
+          name: ocpuser
+      exclude:
+        clusterRoles:
+          - cluster-admin
+          - cluster-image-registry-operator
+          - cluster-node-tuning-operator
+          - kyverno:generatecontroller
+          - kyverno:policycontroller
+          - multus-admission-controller-webhook
+          - openshift-dns-operator
+          - openshift-ingress-operator
+          - syn-admin
+          - syn-argocd-application-controller
+          - syn-argocd-server
+          - syn-resource-locker-*
+          - system:controller:generic-garbage-collector
+          - system:controller:operator-lifecycle-manager
+          - system:master
+          - system:openshift:controller:namespace-security-allocation-controller
+        roles: []
+        subjects:
+          - kind: ServiceAccount
+            name: argocd-application-controller
+            namespace: argocd
+      match:
+        resources:
+          kinds:
+            - Namespace
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              +(appuio.io/organization): '{{ocpuser.metadata.annotations."appuio.io/default-organization"}}'
+      name: set-default-organization
     - exclude:
         clusterRoles:
           - cluster-admin


### PR DESCRIPTION
This PR adds a mutating policy which sets a namespace's `appuio.io/organization` label to the user's default organization (sourced from annotation `appuio.io/default-organization` on the User object) if the namespace which is being created doesn't have the label.

This is implemented in the same cluster policy as the label checking, which works as expected, as mutations are executed before
validations.

Currently the annotations on User objects providing the information about default organizations is generated semi-manually by a Go program which extracts the user's default organization from Keycloak and writes it to the User object.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
