### PR TITLE
Use `request.userInfo.groups` to validate the organization label

### DIFF
--- a/component/namespace-policies.jsonnet
+++ b/component/namespace-policies.jsonnet
@@ -161,23 +161,14 @@ local organizationNamespaces = kyverno.ClusterPolicy('organization-namespaces') 
             value: '',
           },
         ],
-        context: [
-          {
-            name: 'groups',
-            apiCall: {
-              urlPath: '/apis/user.openshift.io/v1/groups',
-              jmesPath: 'items',
-            },
-          },
-        ],
         validate: {
           message: 'Creating namespace for {{request.object.metadata.labels."appuio.io/organization"}} but {{request.userInfo.username}} is not in organization',
           deny: {
             conditions: [
               {
-                key: '{{request.userInfo.username}}',
+                key: '{{request.object.metadata.labels."appuio.io/organization"}}',
                 operator: 'NotIn',
-                value: "{{groups[?metadata.name=='{{request.object.metadata.labels.\"appuio.io/organization\"}}'].users[]}}",
+                value: '{{request.userInfo.groups}}',
               },
             ],
           },

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -103,12 +103,7 @@ spec:
           metadata:
             labels:
               appuio.io/organization: ?*
-    - context:
-        - apiCall:
-            jmesPath: items
-            urlPath: /apis/user.openshift.io/v1/groups
-          name: groups
-      exclude:
+    - exclude:
         clusterRoles:
           - cluster-admin
           - cluster-image-registry-operator
@@ -143,9 +138,9 @@ spec:
       validate:
         deny:
           conditions:
-            - key: '{{request.userInfo.username}}'
+            - key: '{{request.object.metadata.labels."appuio.io/organization"}}'
               operator: NotIn
-              value: '{{groups[?metadata.name==''{{request.object.metadata.labels."appuio.io/organization"}}''].users[]}}'
+              value: '{{request.userInfo.groups}}'
         message: Creating namespace for {{request.object.metadata.labels."appuio.io/organization"}}
           but {{request.userInfo.username}} is not in organization
   validationFailureAction: enforce


### PR DESCRIPTION
Kyverno provides the requesting user's groups in `request.userInfo.groups`.
    
This commit changes the `is-in-organization` policy to use this variable instead of fetching all groups from the Kubernetes API when validating that the user is part of the organization specified on the Namespace object.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
