### PR TITLE
Create OCP project template and add organization label to projects

### DIFF
--- a/class/appuio-cloud.yml
+++ b/class/appuio-cloud.yml
@@ -9,5 +9,6 @@ parameters:
           - appuio-cloud/component/main.jsonnet
           - appuio-cloud/component/namespace-policies.jsonnet
           - appuio-cloud/component/generated-rolebindings.jsonnet
+          - appuio-cloud/component/project-template.jsonnet
         input_type: jsonnet
         output_path: appuio-cloud/

--- a/component/project-template.jsonnet
+++ b/component/project-template.jsonnet
@@ -1,0 +1,44 @@
+local kube = import 'lib/kube.libjsonnet';
+local projectTemplate =
+  kube._Object('template.openshift.io/v1', 'Template', 'project-request') {
+    metadata+: {
+      namespace: 'openshift-config',
+    },
+    objects: [
+      {
+        apiVersion: 'project.openshift.io/v1',
+        kind: 'Project',
+        metadata: {
+          annotations: {
+            'openshift.io/description': '${PROJECT_DESCRIPTION}',
+            'openshift.io/display-name': '${PROJECT_DISPLAYNAME}',
+            'openshift.io/requester': '${PROJECT_REQUESTING_USER}',
+          },
+          name: '${PROJECT_NAME}',
+        },
+      },
+    ],
+    parameters: [
+      { name: 'PROJECT_NAME' },
+      { name: 'PROJECT_DISPLAYNAME' },
+      { name: 'PROJECT_DESCRIPTION' },
+      { name: 'PROJECT_ADMIN_USER' },
+      { name: 'PROJECT_REQUESTING_USER' },
+    ],
+  };
+
+local ocpProjectConfig =
+  kube._Object('config.openshift.io/v1', 'Project', 'cluster') {
+    spec: {
+      projectRequestTemplate: {
+        name: projectTemplate.metadata.name,
+      },
+    },
+  };
+
+{
+  '20_project_template': [
+    ocpProjectConfig,
+    projectTemplate,
+  ],
+}

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -40,15 +40,35 @@ spec:
             name: argocd-application-controller
             namespace: argocd
       match:
-        resources:
-          kinds:
-            - Namespace
+        all:
+          resources:
+            kinds:
+              - Namespace
       mutate:
         patchStrategicMerge:
           metadata:
             labels:
               +(appuio.io/organization): '{{ocpuser.metadata.annotations."appuio.io/default-organization"}}'
-      name: set-default-organization
+      name: set-default-organization-ns
+    - context:
+        - apiCall:
+            jmesPath: '@'
+            urlPath: /apis/user.openshift.io/v1/users/{{request.object.metadata.annotations."openshift.io/requester"}}
+          name: ocpuser
+      exclude: {}
+      match:
+        all:
+          - resources:
+              annotations:
+                openshift.io/requester: ?*
+              kinds:
+                - Project
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              +(appuio.io/organization): '{{ocpuser.metadata.annotations."appuio.io/default-organization"}}'
+      name: set-default-organization-project
     - exclude:
         clusterRoles:
           - cluster-admin

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/20_project_template.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/20_project_template.yaml
@@ -1,0 +1,34 @@
+apiVersion: config.openshift.io/v1
+kind: Project
+metadata:
+  annotations: {}
+  labels:
+    name: cluster
+  name: cluster
+spec:
+  projectRequestTemplate:
+    name: project-request
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  annotations: {}
+  labels:
+    name: project-request
+  name: project-request
+  namespace: openshift-config
+objects:
+  - apiVersion: project.openshift.io/v1
+    kind: Project
+    metadata:
+      annotations:
+        openshift.io/description: ${PROJECT_DESCRIPTION}
+        openshift.io/display-name: ${PROJECT_DISPLAYNAME}
+        openshift.io/requester: ${PROJECT_REQUESTING_USER}
+      name: ${PROJECT_NAME}
+parameters:
+  - name: PROJECT_NAME
+  - name: PROJECT_DISPLAYNAME
+  - name: PROJECT_DESCRIPTION
+  - name: PROJECT_ADMIN_USER
+  - name: PROJECT_REQUESTING_USER


### PR DESCRIPTION
This PR configures a custom OCP project template which only creates a `Project` resource and no rolebindings.

The PR also adds a mutate policy which adds the requesting user's default organization to the project based on the value of annotation
`openshift.io/requester` on the Project resource created by the OCP project template.

Additionally, we refactor the code a bit since this new mutate policy is mostly identical to the one which handles setting a default organization when users create projects with `kubectl create ns`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
