### PR TITLE
Use recommended syntax for Kyverno match and exclude configurations

### DIFF
--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -21,11 +21,26 @@ local flattenSet(set) = std.flatMap(function(s)
   * bypassNamespaceRestrictionsSubjects returns an object containing the configured roles and subjects
   * allowed to bypass restrictions.
   */
-local bypassNamespaceRestrictionsSubjects() = {
-  local bypass = params.bypassNamespaceRestrictions,
-  clusterRoles+: flattenSet(bypass.clusterRoles),
-  roles+: flattenSet(bypass.roles),
-  subjects+: flattenSet(bypass.subjects),
+local bypassNamespaceRestrictionsSubjects() =
+  local bypass = params.bypassNamespaceRestrictions;
+  // FIXME: We would like to nest excludes under `all`. This doesn't work for
+  // clusterRoles in Kyverno 1.4.2, cf. https://github.com/kyverno/kyverno/issues/2301
+  {
+    clusterRoles+: flattenSet(bypass.clusterRoles),
+    roles+: flattenSet(bypass.roles),
+    subjects+: flattenSet(bypass.subjects),
+  };
+
+local matchNamespaces(selector=null, names=null) = {
+  all+: [ {
+    resources+: std.prune({
+      kinds+: [
+        'Namespace',
+      ],
+      selector+: selector,
+      names+: names,
+    }),
+  } ],
 };
 
 
@@ -33,4 +48,5 @@ local bypassNamespaceRestrictionsSubjects() = {
   DefaultLabels: defaultLabels,
   FlattenSet: flattenSet,
   BypassNamespaceRestrictionsSubjects: bypassNamespaceRestrictionsSubjects,
+  MatchNamespaces: matchNamespaces,
 }

--- a/component/generated-rolebindings.jsonnet
+++ b/component/generated-rolebindings.jsonnet
@@ -17,21 +17,16 @@ local generateDefaultRolebindingInNsPolicy = kyverno.ClusterPolicy('default-role
     rules: [
       {
         name: 'default-rolebinding',
-        match: {
-          resources: {
-            kinds: [
-              'Namespace',
+        match: common.MatchNamespaces(
+          selector={
+            matchExpressions: [
+              {
+                key: 'appuio.io/organization',
+                operator: 'Exists',
+              },
             ],
-            selector: {
-              matchExpressions: [
-                {
-                  key: 'appuio.io/organization',
-                  operator: 'Exists',
-                },
-              ],
-            },
-          },
-        },
+          }
+        ),
         generate: {
           kind: 'RoleBinding',
           synchronize: false,

--- a/component/namespace-policies.jsonnet
+++ b/component/namespace-policies.jsonnet
@@ -43,16 +43,6 @@ local appuioNsProvisionersRoleBinding = kube.ClusterRoleBinding('appuio-ns-provi
   ],
 };
 
-local matchAllNamespaces = {
-  all: {
-    resources: {
-      kinds: [
-        'Namespace',
-      ],
-    },
-  },
-};
-
 local matchProjectRequestProjects = {
   all: [ {
     resources: {
@@ -113,7 +103,7 @@ local organizationNamespaces = kyverno.ClusterPolicy('organization-namespaces') 
     rules: [
       setDefaultOrgPolicy(
         'set-default-organization-ns',
-        matchAllNamespaces,
+        common.MatchNamespaces(),
         common.BypassNamespaceRestrictionsSubjects(),
         '{{request.userInfo.username}}'
       ),
@@ -125,13 +115,7 @@ local organizationNamespaces = kyverno.ClusterPolicy('organization-namespaces') 
       ),
       {
         name: 'has-organization',
-        match: {
-          resources: {
-            kinds: [
-              'Namespace',
-            ],
-          },
-        },
+        match: common.MatchNamespaces(),
         exclude: common.BypassNamespaceRestrictionsSubjects(),
         validate: {
           message: 'Namespace must have organization',
@@ -146,13 +130,7 @@ local organizationNamespaces = kyverno.ClusterPolicy('organization-namespaces') 
       },
       {
         name: 'is-in-organization',
-        match: {
-          resources: {
-            kinds: [
-              'Namespace',
-            ],
-          },
-        },
+        match: common.MatchNamespaces(),
         exclude: common.BypassNamespaceRestrictionsSubjects(),
         preconditions: [
           {
@@ -192,14 +170,9 @@ local disallowReservedNamespaces = kyverno.ClusterPolicy('disallow-reserved-name
     rules: [
       {
         name: 'disallow-reserved-namespaces',
-        match: {
-          resources: {
-            kinds: [
-              'Namespace',
-            ],
-            names: common.FlattenSet(params.reservedNamespaces),
-          },
-        },
+        match: common.MatchNamespaces(
+          names=common.FlattenSet(params.reservedNamespaces),
+        ),
         exclude: common.BypassNamespaceRestrictionsSubjects(),
         validate: {
           message: 'Changing or creating reserved namespaces is not allowed.',

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
@@ -35,15 +35,16 @@ spec:
             name: argocd-application-controller
             namespace: argocd
       match:
-        resources:
-          kinds:
-            - Namespace
-          names:
-            - appuio-*
-            - default
-            - kube-*
-            - openshift-*
-            - syn-*
+        all:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - appuio-*
+                - default
+                - kube-*
+                - openshift-*
+                - syn-*
       name: disallow-reserved-namespaces
       validate:
         deny: {}

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -41,9 +41,9 @@ spec:
             namespace: argocd
       match:
         all:
-          resources:
-            kinds:
-              - Namespace
+          - resources:
+              kinds:
+                - Namespace
       mutate:
         patchStrategicMerge:
           metadata:
@@ -93,9 +93,10 @@ spec:
             name: argocd-application-controller
             namespace: argocd
       match:
-        resources:
-          kinds:
-            - Namespace
+        all:
+          - resources:
+              kinds:
+                - Namespace
       name: has-organization
       validate:
         message: Namespace must have organization
@@ -127,9 +128,10 @@ spec:
             name: argocd-application-controller
             namespace: argocd
       match:
-        resources:
-          kinds:
-            - Namespace
+        all:
+          - resources:
+              kinds:
+                - Namespace
       name: is-in-organization
       preconditions:
         - key: '{{request.object.metadata.labels."appuio.io/organization"}}'

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
@@ -24,11 +24,12 @@ spec:
         namespace: '{{request.object.metadata.name}}'
         synchronize: false
       match:
-        resources:
-          kinds:
-            - Namespace
-          selector:
-            matchExpressions:
-              - key: appuio.io/organization
-                operator: Exists
+        all:
+          - resources:
+              kinds:
+                - Namespace
+              selector:
+                matchExpressions:
+                  - key: appuio.io/organization
+                    operator: Exists
       name: default-rolebinding


### PR DESCRIPTION
According to https://kyverno.io/docs/writing-policies/match-exclude/ Kyverno is planning to deprecate configurations which specify resource filters directly under keys `match` or `exclude` and recommends to use either key `all` or `any` under those keys.

Each clause can have exactly one of `all` or `any`.

This commit restructures all our policies to use subkey `all` under `match`. We currently don't nest the cluster roles to exclude under a subkey as there's an open bug that matching of cluster roles doesn't work if they're nested under `all` or `any`, cf https://github.com/kyverno/kyverno/issues/2301.





## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
