### PR TITLE
Update CPU/Mem resource quotas

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -48,6 +48,8 @@ parameters:
           count/configmaps: "150"
           count/secrets: "150"
           count/services: "20"
+          count/services.loadbalancers: "0"
+          count/services.nodeports: "0"
           count/pods: "45"
           count/replicationcontrollers: "100"
           openshift.io/imagestreams: "20"

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -39,10 +39,10 @@ parameters:
         synchronize: true
         hard:
           # See https://kb.vshn.ch/appuio-cloud/references/quality-requirements/performance/resource-quota.html
-          requests.cpu: 2000m
-          requests.memory: 3Gi
-          limits.cpu: 4000m
-          limits.memory: 6Gi
+          requests.cpu: 1000m
+          requests.memory: 4Gi
+          limits.cpu: 1500m
+          limits.memory: 4Gi
           requests.storage: 50Gi
           persistentvolumeclaims: "50"
           count/configmaps: "150"

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -48,6 +48,8 @@ parameters:
           count/configmaps: "150"
           count/secrets: "150"
           count/services: "20"
+          count/pods: "45"
+          count/replicationcontrollers: "100"
           openshift.io/imagestreams: "20"
           openshift.io/imagestreamtags: "50"
         scopes: []

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -48,13 +48,13 @@ spec:
               count/configmaps: '150'
               count/secrets: '150'
               count/services: '20'
-              limits.cpu: 4000m
-              limits.memory: 6Gi
+              limits.cpu: 1500m
+              limits.memory: 4Gi
               openshift.io/imagestreams: '20'
               openshift.io/imagestreamtags: '50'
               persistentvolumeclaims: '50'
-              requests.cpu: 2000m
-              requests.memory: 3Gi
+              requests.cpu: 1000m
+              requests.memory: 4Gi
               requests.storage: 50Gi
             scopeSelector: null
             scopes: []

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -46,6 +46,8 @@ spec:
           spec:
             hard:
               count/configmaps: '150'
+              count/pods: '45'
+              count/replicationcontrollers: '100'
               count/secrets: '150'
               count/services: '20'
               limits.cpu: 1500m

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -50,6 +50,8 @@ spec:
               count/replicationcontrollers: '100'
               count/secrets: '150'
               count/services: '20'
+              count/services.loadbalancers: '0'
+              count/services.nodeports: '0'
               limits.cpu: 1500m
               limits.memory: 4Gi
               openshift.io/imagestreams: '20'


### PR DESCRIPTION
> Looking at the current usage, around two thirds of the namespaces use 4GiB or less memory.
> This sounds like a reasonable quota to start with.
> For the compute resources, let's assume a node size of 32GB memory with 8 CPU cores (Plus-32 on Cloudscale and Huge on Exoscale).
> This results in 8 namespaces per node and therefore we can restrict the CPU requests to 1 core and the CPU limit to 1.5 cores.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
