### PR TITLE
Disallow docker build strategy

### DIFF
--- a/class/appuio-cloud.yml
+++ b/class/appuio-cloud.yml
@@ -12,5 +12,6 @@ parameters:
           - appuio-cloud/component/project-template.jsonnet
           - appuio-cloud/component/project-policies.jsonnet
           - appuio-cloud/component/quota-limitrange.jsonnet
+          - appuio-cloud/component/build-strategy.jsonnet
         input_type: jsonnet
         output_path: appuio-cloud/

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -87,3 +87,5 @@ parameters:
             memory: "100Mi"
             # 250Mi (requests.ephemeral-storage) / 45 (count/pods) = ~5Mi
             ephemeral-storage: "5Mi"
+
+    disallowDockerBuildStrategy: true

--- a/component/build-strategy.jsonnet
+++ b/component/build-strategy.jsonnet
@@ -17,5 +17,6 @@ local disallowDockerBuildStrategyPatch = {
 };
 
 {
-  '15_disallow_docker_build_strategy_patch': resourceLocker.Patch(bindingToPatch, disallowDockerBuildStrategyPatch),
+  [if params.disallowDockerBuildStrategy then '15_disallow_docker_build_strategy_patch']:
+    resourceLocker.Patch(bindingToPatch, disallowDockerBuildStrategyPatch),
 }

--- a/component/build-strategy.jsonnet
+++ b/component/build-strategy.jsonnet
@@ -1,0 +1,21 @@
+local common = import 'common.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local resourceLocker = import 'lib/resource-locker.libjsonnet';
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.appuio_cloud;
+
+// See https://docs.openshift.com/container-platform/4.8/cicd/builds/securing-builds-by-strategy.html#builds-disabling-build-strategy-globally_securing-builds-by-strategy
+local bindingToPatch = kube.ClusterRoleBinding('system:build-strategy-docker-binding');
+
+local disallowDockerBuildStrategyPatch = {
+  annotations: {
+    'rbac.authorization.kubernetes.io/autoupdate': 'false',
+  },
+  subjects: [],
+};
+
+{
+  '15_disallow_docker_build_strategy_patch': resourceLocker.Patch(bindingToPatch, disallowDockerBuildStrategyPatch),
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -217,3 +217,10 @@ It will also reject any container requesting more than `4G` of memory or less th
 
 Consult https://kubernetes.io/docs/concepts/policy/limit-range/[the official Kubernetes documentation] on how to configure these `limits`.
 
+== `disallowDockerBuildStrategy`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Creating https://docs.openshift.com/container-platform/4.7/cicd/builds/build-strategies.html#builds-strategy-docker-build_build-strategies[build strategies using Docker] is disallowed.

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -7,7 +7,7 @@ parameters:
         source: https://raw.githubusercontent.com/projectsyn/component-kyverno/v1.1.0/lib/kyverno.libsonnet
         output_path: vendor/lib/kyverno.libsonnet
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/allow-patching-crb/lib/resource-locker.libjsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.0.1/lib/resource-locker.libjsonnet
         output_path: vendor/lib/resource-locker.libjsonnet
 
   appuio_cloud:

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -6,6 +6,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-kyverno/v1.1.0/lib/kyverno.libsonnet
         output_path: vendor/lib/kyverno.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/allow-patching-crb/lib/resource-locker.libjsonnet
+        output_path: vendor/lib/resource-locker.libjsonnet
 
   appuio_cloud:
     bypassNamespaceRestrictions:
@@ -14,3 +17,6 @@ parameters:
           kind: ServiceAccount
           name: argocd-application-controller
           namespace: argocd
+
+  resource_locker:
+    namespace: syn-resource-locker

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/15_disallow_docker_build_strategy_patch.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/15_disallow_docker_build_strategy_patch.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: system-build-strategy-docker-binding-manager
+  name: system-build-strategy-docker-binding-manager
+  namespace: syn-resource-locker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    name: syn-resource-locker-ystem-build-strategy-docker-binding-manager
+  name: syn-resource-locker-ystem-build-strategy-docker-binding-manager
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    name: syn-resource-locker-ystem-build-strategy-docker-binding-manager
+  name: syn-resource-locker-ystem-build-strategy-docker-binding-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-resource-locker-ystem-build-strategy-docker-binding-manager
+subjects:
+  - kind: ServiceAccount
+    name: system-build-strategy-docker-binding-manager
+    namespace: syn-resource-locker
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: system-build-strategy-docker-binding
+  name: system-build-strategy-docker-binding
+  namespace: syn-resource-locker
+spec:
+  patches:
+    - id: patch1
+      patchTemplate: "\"annotations\":\n  \"rbac.authorization.kubernetes.io/autoupdate\"\
+        : \"false\"\n\"subjects\": []"
+      patchType: application/strategic-merge-patch+json
+      targetObjectRef:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: system:build-strategy-docker-binding
+  serviceAccountRef:
+    name: system-build-strategy-docker-binding-manager


### PR DESCRIPTION
This PR disallows the OpenShift Docker build strategy.

```sh 
❯ kubectl apply -f- << YAML 
apiVersion: build.openshift.io/v1
kind: BuildConfig
metadata:
  name: docker-buildconfig
spec:
  strategy:
    dockerStrategy: {}
  source:
    dockerfile: "FROM alpine\nRUN apk add curl"
---
apiVersion: build.openshift.io/v1
kind: BuildConfig
metadata:
  name: source-buildconfig
spec:
  strategy:
    jenkinsPipelineStrategy: {}
  source:
    git:
      uri: https://github.com/appuio/component-appuio-cloud.git
YAML

buildconfig.build.openshift.io/source-buildconfig created
Error from server (Forbidden): error when creating "STDIN": buildconfigs.build.openshift.io "docker-buildconfig" is forbidden: build strategy Docker is not allowed
```

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
