### PR TITLE
Remove limits for ephemeral storage

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -71,8 +71,6 @@ parameters:
           max:
             cpu: "1"
             memory: "4G"
-            # limits.ephemeral-storage
-            ephemeral-storage: "500Mi"
           min:
             cpu: "10m"
             memory: "4Mi"
@@ -80,12 +78,8 @@ parameters:
           default:
             cpu: "200m"
             memory: "200Mi"
-            # 500Mi (limits.ephemeral-storage) / 45 (count/pods) = ~10Mi
-            ephemeral-storage: "10Mi"
           defaultRequest:
             cpu: "100m"
             memory: "100Mi"
-            # 250Mi (requests.ephemeral-storage) / 45 (count/pods) = ~5Mi
-            ephemeral-storage: "5Mi"
 
     disallowDockerBuildStrategy: true

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -16,15 +16,12 @@ spec:
             limits:
               - default:
                   cpu: 200m
-                  ephemeral-storage: 10Mi
                   memory: 200Mi
                 defaultRequest:
                   cpu: 100m
-                  ephemeral-storage: 5Mi
                   memory: 100Mi
                 max:
                   cpu: '1'
-                  ephemeral-storage: 500Mi
                   memory: 4G
                 min:
                   cpu: 10m


### PR DESCRIPTION
Seems to cause issues.

e.g. `oc new-app rails-postgresql-example` fails with
`Pod ephemeral local storage usage exceeds the total limit of containers 10Mi. `

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
