### PR TITLE
Change default name for generated admin rolebinding to `organization-admin`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -31,7 +31,7 @@ parameters:
       appuio: appuio-*
 
     generatedDefaultRoleBindingInNewNamespaces:
-      bindingName: admin
+      bindingName: organization-admin
       clusterRoleName: admin
 
     generatedResourceQuota:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -87,7 +87,7 @@ The `ClusterRole` name to which the requesting user account gets a new `RoleBind
 
 [horizontal]
 type:: string
-default:: `admin`
+default:: `organization-admin`
 
 The `metadata.name` of the `RoleBinding` that gets generated in the new `Namespace` created by the user.
 The role binding is only created upon Namespace creation, it doesn't get synchronized.

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
@@ -20,7 +20,7 @@ spec:
             - kind: Group
               name: '{{request.object.metadata.labels."appuio.io/organization"}}'
         kind: RoleBinding
-        name: admin
+        name: organization-admin
         namespace: '{{request.object.metadata.name}}'
         synchronize: false
       match:


### PR DESCRIPTION
This avoids Kyverno overwriting the `admin` rolebinding created by the OpenShift default project template.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
