### PR TITLE
Split resource quotas into `objects`, `compute` and `compute-terminating`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -35,22 +35,16 @@ parameters:
       clusterRoleName: admin
 
     generatedResourceQuota:
-      "organization":
+      # See https://kb.vshn.ch/appuio-cloud/references/quality-requirements/performance/resource-quota.html
+      organization-objects:
         synchronize: true
         spec:
           hard:
-            # See https://kb.vshn.ch/appuio-cloud/references/quality-requirements/performance/resource-quota.html
-            requests.cpu: 1000m
-            requests.memory: 4Gi
-            limits.cpu: 1500m
-            limits.memory: 4Gi
-
             count/configmaps: "150"
             count/secrets: "150"
             count/services: "20"
             count/services.loadbalancers: "0"
             count/services.nodeports: "0"
-            count/pods: "45"
             count/replicationcontrollers: "100"
             openshift.io/imagestreams: "20"
             openshift.io/imagestreamtags: "50"
@@ -61,8 +55,29 @@ parameters:
             requests.ephemeral-storage: "250Mi"
             limits.ephemeral-storage: "500Mi"
 
-          scopes: []
-          scopeSelector:
+      organization-compute:
+        synchronize: true
+        spec:
+          hard:
+            requests.cpu: 1000m
+            requests.memory: 4Gi
+            limits.cpu: 2
+            limits.memory: 20Gi
+            pods: "45"
+          scopes:
+            - NotTerminating
+
+      organization-compute-terminating:
+        synchronize: true
+        spec:
+          hard:
+            requests.cpu: 1000m
+            requests.memory: 2Gi
+            limits.cpu: 2000m
+            limits.memory: 4Gi
+            pods: "5"
+          scopes:
+            - Terminating
 
     generatedLimitRange:
       name: organization

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -37,31 +37,32 @@ parameters:
     generatedResourceQuota:
       "organization":
         synchronize: true
-        hard:
-          # See https://kb.vshn.ch/appuio-cloud/references/quality-requirements/performance/resource-quota.html
-          requests.cpu: 1000m
-          requests.memory: 4Gi
-          limits.cpu: 2
-          limits.memory: 20Gi
+        spec:
+          hard:
+            # See https://kb.vshn.ch/appuio-cloud/references/quality-requirements/performance/resource-quota.html
+            requests.cpu: 1000m
+            requests.memory: 4Gi
+            limits.cpu: 1500m
+            limits.memory: 4Gi
 
-          count/configmaps: "150"
-          count/secrets: "150"
-          count/services: "20"
-          count/services.loadbalancers: "0"
-          count/services.nodeports: "0"
-          count/pods: "45"
-          count/replicationcontrollers: "100"
-          openshift.io/imagestreams: "20"
-          openshift.io/imagestreamtags: "50"
+            count/configmaps: "150"
+            count/secrets: "150"
+            count/services: "20"
+            count/services.loadbalancers: "0"
+            count/services.nodeports: "0"
+            count/pods: "45"
+            count/replicationcontrollers: "100"
+            openshift.io/imagestreams: "20"
+            openshift.io/imagestreamtags: "50"
 
-          requests.storage: 1000Gi
-          persistentvolumeclaims: "10"
-          localblock-storage.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
-          requests.ephemeral-storage: "250Mi"
-          limits.ephemeral-storage: "500Mi"
+            requests.storage: 1000Gi
+            persistentvolumeclaims: "10"
+            localblock-storage.storageclass.storage.k8s.io/persistentvolumeclaims: "0"
+            requests.ephemeral-storage: "250Mi"
+            limits.ephemeral-storage: "500Mi"
 
-        scopes: []
-        scopeSelector:
+          scopes: []
+          scopeSelector:
 
     generatedLimitRange:
       name: organization

--- a/component/quota-limitrange.jsonnet
+++ b/component/quota-limitrange.jsonnet
@@ -40,11 +40,7 @@ local generateQuotaLimitRangeInNsPolicy = kyverno.ClusterPolicy('quota-and-limit
           name: k,
           namespace: '{{request.object.metadata.name}}',
           data: {
-            spec: {
-              hard: params.generatedResourceQuota[k].hard,
-              scopes: params.generatedResourceQuota[k].scopes,
-              scopeSelector: params.generatedResourceQuota[k].scopeSelector,
-            },
+            spec: params.generatedResourceQuota[k].spec,
           },
         },
       }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -97,7 +97,7 @@ The role binding is only created upon Namespace creation, it doesn't get synchro
 [horizontal]
 type:: dict
 
-A key-value map defining multiple `ResourceQuota`.
+A key-value map defining `ResourceQuota` objects.
 Each entry will generate a `ResourceQuota` with the key as its name.
 
 === `generatedResourceQuota[name].synchronize`
@@ -116,52 +116,14 @@ The bug has been fixed, but as of writing this the fix hasn't been released.
 The bug will cause the `ResourceQuota` to be updated if the `Namespace` or `ClusterPolicy` changes, even if `synchronize` has been disabled.
 ====
 
-=== `generatedResourceQuota[name].hard`
+=== `generatedResourceQuota[name].spec`
 
 [horizontal]
 type:: dict
 
-The desired hard limits for each named resource.
-Consult https://kubernetes.io/docs/concepts/policy/resource-quotas/[the official Kubernetes documentation] on how to configure these limits.
-
-
-=== `generatedResourceQuota[name].scopes`
-
-[horizontal]
-type:: list
-default:: []
-example::
-+
-[source,yaml]
-----
-scopes:
-  - Terminating
-  - BestEffort
-----
-
-Each quota can have an associated set of scopes.
-A quota will only measure usage for a resource if it matches the intersection of enumerated scopes.
-Consult https://kubernetes.io/docs/concepts/policy/resource-quotas/#quota-scopes[the official Kubernetes documentation] on how to configure these scopes.
-
-=== `generatedResourceQuota[name].scopeSelector`
-
-ScopeSelector is also a collection of filters like Scopes that must match each object tracked by a quota.
-Consult https://kubernetes.io/docs/concepts/policy/resource-quotas/#quota-scopes[the official Kubernetes documentation] on how to configure this `scopeSelector`.
-
-[horizontal]
-type:: dict
-default:: null
-example::
-+
-[source,yaml]
-----
-scopeSelector:
-  matchExpressions:
-    - scopeName: PriorityClass
-      operator: In
-      values:
-        - middle
-----
+The desired contents of field `spec` of the ResourceQuota that should be generated.
+The component doesn't validate the contents of this field.
+See the Kubernetes https://kubernetes.io/docs/concepts/policy/resource-quotas/[Resource Quota documentation] for supported configurations.
 
 == `generatedLimitRange.name`
 

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -46,28 +46,15 @@ spec:
         data:
           spec:
             hard:
-              count/configmaps: '150'
-              count/pods: '45'
-              count/replicationcontrollers: '100'
-              count/secrets: '150'
-              count/services: '20'
-              count/services.loadbalancers: '0'
-              count/services.nodeports: '0'
               limits.cpu: 2
-              limits.ephemeral-storage: 500Mi
               limits.memory: 20Gi
-              localblock-storage.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
-              openshift.io/imagestreams: '20'
-              openshift.io/imagestreamtags: '50'
-              persistentvolumeclaims: '10'
+              pods: '45'
               requests.cpu: 1000m
-              requests.ephemeral-storage: 250Mi
               requests.memory: 4Gi
-              requests.storage: 1000Gi
-            scopeSelector: null
-            scopes: []
+            scopes:
+              - NotTerminating
         kind: ResourceQuota
-        name: organization
+        name: organization-compute
         namespace: '{{request.object.metadata.name}}'
         synchronize: true
       match:
@@ -79,4 +66,60 @@ spec:
                 matchExpressions:
                   - key: appuio.io/organization
                     operator: Exists
-      name: generate-quota-organization
+      name: generate-quota-organization-compute
+    - generate:
+        data:
+          spec:
+            hard:
+              limits.cpu: 2000m
+              limits.memory: 4Gi
+              pods: '5'
+              requests.cpu: 1000m
+              requests.memory: 2Gi
+            scopes:
+              - Terminating
+        kind: ResourceQuota
+        name: organization-compute-terminating
+        namespace: '{{request.object.metadata.name}}'
+        synchronize: true
+      match:
+        all:
+          - resources:
+              kinds:
+                - Namespace
+              selector:
+                matchExpressions:
+                  - key: appuio.io/organization
+                    operator: Exists
+      name: generate-quota-organization-compute-terminating
+    - generate:
+        data:
+          spec:
+            hard:
+              count/configmaps: '150'
+              count/replicationcontrollers: '100'
+              count/secrets: '150'
+              count/services: '20'
+              count/services.loadbalancers: '0'
+              count/services.nodeports: '0'
+              limits.ephemeral-storage: 500Mi
+              localblock-storage.storageclass.storage.k8s.io/persistentvolumeclaims: '0'
+              openshift.io/imagestreams: '20'
+              openshift.io/imagestreamtags: '50'
+              persistentvolumeclaims: '10'
+              requests.ephemeral-storage: 250Mi
+              requests.storage: 1000Gi
+        kind: ResourceQuota
+        name: organization-objects
+        namespace: '{{request.object.metadata.name}}'
+        synchronize: true
+      match:
+        all:
+          - resources:
+              kinds:
+                - Namespace
+              selector:
+                matchExpressions:
+                  - key: appuio.io/organization
+                    operator: Exists
+      name: generate-quota-organization-objects


### PR DESCRIPTION
The quotas `organization-compute` and `organization-compute-terminating` apply for non-terminating pods (pods where `.spec.activeDeadlineSeconds` is `nil`) and terminating pods (pods with `.spec.activeDeadlineSeconds` >= 0) respectively.

The `Terminating` and `NotTerminating` scopes restrict quotas to the following resources:

* `pods`
* `cpu`
* `memory`
* `requests.cpu`
* `requests.memory`
* `limits.cpu`
* `limits.memory`

Therefore we need to create a separate quota `organization-objects` for the remaining object quotas which we care about.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
