### PR TITLE
Use same values as on APPUiO Public for terminating compute quota

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -71,10 +71,8 @@ parameters:
         synchronize: true
         spec:
           hard:
-            requests.cpu: 1000m
-            requests.memory: 2Gi
-            limits.cpu: 2000m
-            limits.memory: 4Gi
+            limits.cpu: 1000m
+            limits.memory: 2Gi
             pods: "5"
           scopes:
             - Terminating

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -71,11 +71,9 @@ spec:
         data:
           spec:
             hard:
-              limits.cpu: 2000m
-              limits.memory: 4Gi
+              limits.cpu: 1000m
+              limits.memory: 2Gi
               pods: '5'
-              requests.cpu: 1000m
-              requests.memory: 2Gi
             scopes:
               - Terminating
         kind: ResourceQuota


### PR DESCRIPTION
Fix for #30 which uses the same values as APPUiO Public for the terminating compute quota.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
