### PR TITLE
Add a clusterpolicy to set default for `.spec.activeDeadlineSeconds`

### DIFF
--- a/class/appuio-cloud.yml
+++ b/class/appuio-cloud.yml
@@ -13,5 +13,6 @@ parameters:
           - appuio-cloud/component/project-policies.jsonnet
           - appuio-cloud/component/quota-limitrange.jsonnet
           - appuio-cloud/component/build-strategy.jsonnet
+          - appuio-cloud/component/runonce-activedeadlineseconds.jsonnet
         input_type: jsonnet
         output_path: appuio-cloud/

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -119,4 +119,4 @@ parameters:
 
     runOnceActiveDeadlineSeconds:
       defaultActiveDeadlineSeconds: 1800
-      overrideAnnotationKey: appuio.io/activeDeadlineSecondsOverride
+      overrideAnnotationKey: appuio.io/active-deadline-seconds-override

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -116,3 +116,7 @@ parameters:
         PROJECT_DESCRIPTION: {}
         PROJECT_ADMIN_USER: {}
         PROJECT_REQUESTING_USER: {}
+
+    runOnceActiveDeadlineSeconds:
+      defaultActiveDeadlineSeconds: 1800
+      overrideAnnotationKey: appuio.io/activeDeadlineSecondsOverride

--- a/component/runonce-activedeadlineseconds.jsonnet
+++ b/component/runonce-activedeadlineseconds.jsonnet
@@ -11,9 +11,10 @@ local config = params.runOnceActiveDeadlineSeconds;
 local defaultDeadline = config.defaultActiveDeadlineSeconds;
 local annotationKey = config.overrideAnnotationKey;
 local jmesPath =
-  'to_number(merge(`%s`, metadata.annotations)."%s")' % [
+  'to_number(merge(`%s`, metadata.annotations || `{}`)."%s" ) || `%s`' % [
     { [annotationKey]: defaultDeadline },
     annotationKey,
+    defaultDeadline,
   ];
 
 local policy =

--- a/component/runonce-activedeadlineseconds.jsonnet
+++ b/component/runonce-activedeadlineseconds.jsonnet
@@ -1,0 +1,71 @@
+local common = import 'common.libsonnet';
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kyverno = import 'lib/kyverno.libsonnet';
+
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.appuio_cloud;
+local config = params.runOnceActiveDeadlineSeconds;
+
+local defaultDeadline = config.defaultActiveDeadlineSeconds;
+local annotationKey = config.overrideAnnotationKey;
+local jmesPath =
+  'to_number(merge(`%s`, metadata.annotations)."%s")' % [
+    { [annotationKey]: defaultDeadline },
+    annotationKey,
+  ];
+
+local policy =
+  kyverno.ClusterPolicy('set-runonce-activedeadlineseconds') {
+    metadata+: {
+      annotations+: {
+        'kyverno.syn.tools/policy-description': (
+          'This policy ensures that all "runonce" pods have '
+          + '`.spec.activeDeadlineSeconds` set. The value for '
+          + '`.spec.activeDeadlineSeconds` for a namepsace can '
+          + 'be overridden by adding annotation `%s` with the desired '
+          + 'default value on a namespace.'
+        ) % [ annotationKey ],
+        // Don't autogenerate policies for pod controllers, as we don't want
+        // to inject the activeDeadlineSeconds into controller manifests such
+        // as Jobs or CronJobs which may be managed by CD
+        'pod-policies.kyverno.io/autogen-controllers': 'none',
+      },
+    },
+    spec: {
+      background: false,
+      validationFailureAction: 'enforce',
+      rules: [
+        {
+          name: 'set-runonce-activedeadlineseconds',
+          context: [ {
+            apiCall: {
+              jmesPath: jmesPath,
+              urlPath: '/api/v1/namespaces/{{request.namespace}}',
+            },
+            name: 'activeDeadlineSeconds',
+          } ],
+          match: {
+            resources: {
+              kinds: [
+                'Pod',
+              ],
+            },
+          },
+          mutate: {
+            patchStrategicMerge: {
+              spec: {
+                '(restartPolicy)': 'Never|OnFailure',
+                '+(activeDeadlineSeconds)': '{{activeDeadlineSeconds}}',
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+
+{
+  '30_set_runonce_activedeadlineseconds': policy + common.DefaultLabels,
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -267,6 +267,6 @@ This parameter gives the default value for `.spec.activeDeadlineSeconds` which i
 
 [horizontal]
 type:: string
-default:: `appuio.io/activeDeadlineSecondsOverride`
+default:: `appuio.io/active-deadline-seconds-override`
 
 The key of the namespace annotation which users can use to override the global default value for `.spec.activeDeadlineSeconds`.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -248,3 +248,25 @@ The contents of this dict are used to populate field `parameters` of the OpenShi
 The field `parameters` in the template object is a list of objects, see the https://docs.openshift.com/container-platform/latest/openshift_images/using-templates.html#templates-writing_using-templates[OpenShift documentation].
 The component transforms the entries of this component parameter into objects by using the key as field `name` of the resulting object and merging it with the provided value.
 Users can remove parameters by setting value `null`.
+
+== `runOnceActiveDeadlineSeconds`
+
+Configuration for the cluster policy which ensures that `.spec.activeDeadlineSeconds` is set for all "runonce" pods.
+"Runonce" pods are pods which have `.spec.restartPolicy` set to `OnFailure` or `Never`.
+
+=== `runOnceActiveDeadlineSeconds.defaultActiveDeadlineSeconds`
+
+[horizontal]
+type:: int
+default:: `1800`
+
+This parameter gives the default value for `.spec.activeDeadlineSeconds` which is added to "runonce" pods which don't have the field set already.
+
+=== `runOnceActiveDeadlineSeconds.overrideAnnotationKey`
+
+
+[horizontal]
+type:: string
+default:: `appuio.io/activeDeadlineSecondsOverride`
+
+The key of the namespace annotation which users can use to override the global default value for `.spec.activeDeadlineSeconds`.

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/30_set_runonce_activedeadlineseconds.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/30_set_runonce_activedeadlineseconds.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    kyverno.syn.tools/policy-description: This policy ensures that all "runonce" pods
+      have `.spec.activeDeadlineSeconds` set. The value for `.spec.activeDeadlineSeconds`
+      for a namepsace can be overridden by adding annotation `appuio.io/activeDeadlineSecondsOverride`
+      with the desired default value on a namespace.
+    pod-policies.kyverno.io/autogen-controllers: none
+  labels:
+    app.kubernetes.io/component: appuio-cloud
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud
+    name: set-runonce-activedeadlineseconds
+  name: set-runonce-activedeadlineseconds
+spec:
+  background: false
+  rules:
+    - context:
+        - apiCall:
+            jmesPath: 'to_number(merge(`{"appuio.io/activeDeadlineSecondsOverride":
+              1800}`, metadata.annotations)."appuio.io/activeDeadlineSecondsOverride")'
+            urlPath: /api/v1/namespaces/{{request.namespace}}
+          name: activeDeadlineSeconds
+      match:
+        resources:
+          kinds:
+            - Pod
+      mutate:
+        patchStrategicMerge:
+          spec:
+            (restartPolicy): Never|OnFailure
+            +(activeDeadlineSeconds): '{{activeDeadlineSeconds}}'
+      name: set-runonce-activedeadlineseconds
+  validationFailureAction: enforce

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/30_set_runonce_activedeadlineseconds.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/30_set_runonce_activedeadlineseconds.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     kyverno.syn.tools/policy-description: This policy ensures that all "runonce" pods
       have `.spec.activeDeadlineSeconds` set. The value for `.spec.activeDeadlineSeconds`
-      for a namepsace can be overridden by adding annotation `appuio.io/activeDeadlineSecondsOverride`
+      for a namepsace can be overridden by adding annotation `appuio.io/active-deadline-seconds-override`
       with the desired default value on a namespace.
     pod-policies.kyverno.io/autogen-controllers: none
   labels:
@@ -18,8 +18,8 @@ spec:
   rules:
     - context:
         - apiCall:
-            jmesPath: 'to_number(merge(`{"appuio.io/activeDeadlineSecondsOverride":
-              1800}`, metadata.annotations || `{}`)."appuio.io/activeDeadlineSecondsOverride"
+            jmesPath: 'to_number(merge(`{"appuio.io/active-deadline-seconds-override":
+              1800}`, metadata.annotations || `{}`)."appuio.io/active-deadline-seconds-override"
               ) || `1800`'
             urlPath: /api/v1/namespaces/{{request.namespace}}
           name: activeDeadlineSeconds

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/30_set_runonce_activedeadlineseconds.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/30_set_runonce_activedeadlineseconds.yaml
@@ -19,7 +19,8 @@ spec:
     - context:
         - apiCall:
             jmesPath: 'to_number(merge(`{"appuio.io/activeDeadlineSecondsOverride":
-              1800}`, metadata.annotations)."appuio.io/activeDeadlineSecondsOverride")'
+              1800}`, metadata.annotations || `{}`)."appuio.io/activeDeadlineSecondsOverride"
+              ) || `1800`'
             urlPath: /api/v1/namespaces/{{request.namespace}}
           name: activeDeadlineSeconds
       match:


### PR DESCRIPTION
Create a new cluster policy which ensures that `.spec.activeDeadlineSeconds` is set on all "runonce" pods (pods with `.spec.restartPolicy` set to "OnFailure" or "Never").

This policy doesn't modify "runonce" pods which already have `.spec.activeDeadlineSeconds` set.

All other "runonce" pods are configured with the global default activeDeadlineSeconds value extracted from component parameter `runOnceActiveDeadlineSeconds.defaultActiveDeadlineSeconds`.

Users can override the default value on individual namespaces by setting annotation with key `runOnceActiveDeadlineSeconds.overrideAnnotationKey` to the desired default value for pods in that namespace.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
