### PR TITLE
Enable namespace transfer

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -34,6 +34,9 @@ parameters:
       bindingName: organization-admin
       clusterRoleName: admin
 
+    generatedNamespaceOwnerRole:
+      name: namespace-owner
+
     generatedResourceQuota:
       # See https://kb.vshn.ch/appuio-cloud/references/quality-requirements/performance/resource-quota.html
       organization-objects:

--- a/component/generated-rolebindings.jsonnet
+++ b/component/generated-rolebindings.jsonnet
@@ -38,6 +38,57 @@ local generateDefaultRolebindingInNsPolicy = kyverno.ClusterPolicy('default-role
           },
         },
       },
+      {
+        name: 'namespace-edit-role',
+        match: common.MatchOrgNamespaces,
+        generate: {
+          kind: 'Role',
+          synchronize: false,
+          name: params.generatedNamespaceOwnerRole.name,
+          namespace: '{{request.object.metadata.name}}',
+          data: {
+            rules: [
+              {
+                apiGroups: [
+                  '',
+                ],
+                resources: [
+                  'namespaces',
+                ],
+                verbs: [
+                  'get',
+                  'watch',
+                  'edit',
+                  'patch',
+                ],
+              },
+            ],
+          },
+        },
+      },
+      {
+        name: 'namespace-edit-rolebinding',
+        match: common.MatchOrgNamespaces,
+        generate: {
+          kind: 'RoleBinding',
+          synchronize: false,
+          name: params.generatedNamespaceOwnerRole.name,
+          namespace: '{{request.object.metadata.name}}',
+          data: {
+            roleRef: {
+              apiGroup: 'rbac.authorization.k8s.io',
+              kind: 'Role',
+              name: params.generatedNamespaceOwnerRole.name,
+            },
+            subjects: [
+              {
+                kind: 'Group',
+                name: '{{request.object.metadata.labels."appuio.io/organization"}}',
+              },
+            ],
+          },
+        },
+      },
     ],
   },
 };

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -92,6 +92,14 @@ default:: `organization-admin`
 The `metadata.name` of the `RoleBinding` that gets generated in the new `Namespace` created by the user.
 The role binding is only created upon Namespace creation, it doesn't get synchronized.
 
+== `generatedNamespaceOwnerRole.name`
+
+[horizontal]
+type:: string
+default:: `namespace-owner`
+
+The `Role` and `RoleBinding` name for the role that allows users to edit the new `Namespace`
+
 == `generatedResourceQuota`
 
 [horizontal]

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
@@ -33,3 +33,52 @@ spec:
                   - key: appuio.io/organization
                     operator: Exists
       name: default-rolebinding
+    - generate:
+        data:
+          rules:
+            - apiGroups:
+                - ''
+              resources:
+                - namespaces
+              verbs:
+                - get
+                - watch
+                - edit
+                - patch
+        kind: Role
+        name: namespace-owner
+        namespace: '{{request.object.metadata.name}}'
+        synchronize: false
+      match:
+        all:
+          - resources:
+              kinds:
+                - Namespace
+              selector:
+                matchExpressions:
+                  - key: appuio.io/organization
+                    operator: Exists
+      name: namespace-edit-role
+    - generate:
+        data:
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: namespace-owner
+          subjects:
+            - kind: Group
+              name: '{{request.object.metadata.labels."appuio.io/organization"}}'
+        kind: RoleBinding
+        name: namespace-owner
+        namespace: '{{request.object.metadata.name}}'
+        synchronize: false
+      match:
+        all:
+          - resources:
+              kinds:
+                - Namespace
+              selector:
+                matchExpressions:
+                  - key: appuio.io/organization
+                    operator: Exists
+      name: namespace-edit-rolebinding


### PR DESCRIPTION
To allow users to transfer a namespace we need to allow them to edit it.

The existing policies will check that the user is part of the target organization.

I'm not really happy with the naming. I'm open for suggestions

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
