### PR TITLE
Change default namespace

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   appuio_cloud:
     =_metadata: {}
-    namespace: syn-appuio-cloud
+    namespace: appuio-cloud
 
     bypassNamespaceRestrictions:
       roles: {}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -6,7 +6,7 @@ The parent key for all of the following parameters is `appuio_cloud`.
 
 [horizontal]
 type:: string
-default:: `syn-appuio-cloud`
+default:: `appuio-cloud`
 
 The namespace in which to deploy this component.
 

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/00_namespace.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/00_namespace.yaml
@@ -6,5 +6,5 @@ metadata:
     app.kubernetes.io/component: appuio-cloud
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: appuio-cloud
-    name: syn-appuio-cloud
-  name: syn-appuio-cloud
+    name: appuio-cloud
+  name: appuio-cloud


### PR DESCRIPTION
This component isn't really part of Project Syn, just managed by it.
Therefore it should belong to its own namespace prefix 'appuio'

NOTE: At this moment, this component doesn't deploy any namespace-scoped resources, so it shouldn't break anything.
Also, it better aligns with Keycloak IdP, which is installed in `appuio-keycloak`

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
