### PR TITLE
Add Cilium to the list of reserved namespaces

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -29,6 +29,7 @@ parameters:
       openshift: openshift-*
       projectsyn: syn-*
       appuio: appuio-*
+      cilium: cilium*
 
     allowedNamespaceLabels:
       kubernetesGenerated:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
@@ -41,6 +41,7 @@ spec:
                 - Namespace
               names:
                 - appuio-*
+                - cilium*
                 - default
                 - kube-*
                 - openshift-*


### PR DESCRIPTION
Cilium is installed in the namespace `cilium`. Now that we opted to make use of it, we need to protect that namespace from end user interference.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
