### PR TITLE
Ignore Kyverno mutate debug annotation

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -41,6 +41,13 @@ parameters:
         - kubectl.kubernetes.io/last-applied-configuration
       appuioUserDefined: custom.appuio.io/*
       runOnceActiveDeadlineSecondsOverride: ${appuio_cloud:runOnceActiveDeadlineSeconds:overrideAnnotationKey}
+      # If using mutate, Kyverno appends an annotation to debug the mutate patches.
+      # The annotation is appended in the context of the original requestor.
+      # Thus we have to whitelist the annotation or the later validation rejects the request.
+      # This should be safe because:
+      # - The annotation is only for debugging and not referenced elsewhere.
+      # - The mutating policies are validated with a validation rule too.
+      kyvernoMutateLabel: policies.kyverno.io/last-applied-patches
 
     generatedDefaultRoleBindingInNewNamespaces:
       bindingName: organization-admin

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
@@ -117,6 +117,7 @@ spec:
                     value: true
                   - key: '{{regex_match(`"^custom.appuio.io/.*$"`, `"{{element.key}}"`)
                       || regex_match(`"^kubectl.kubernetes.io/last-applied-configuration$"`,
+                      `"{{element.key}}"`) || regex_match(`"^policies.kyverno.io/last-applied-patches$"`,
                       `"{{element.key}}"`) || regex_match(`"^appuio.io/active-deadline-seconds-override$"`,
                       `"{{element.key}}"`) || regex_match(`"^test.appuio.io/.*$"`,
                       `"{{element.key}}"`) || regex_match(`"^compute.test.appuio.io/cpu$"`,
@@ -127,8 +128,8 @@ spec:
               `{}`)   ,not_null(request.oldObject.metadata.annotations, `{}`))  |
               map(&{key: @}, keys(@))'
         message: "The following annotations can be modified:\n    custom.appuio.io/*,\
-          \ kubectl.kubernetes.io/last-applied-configuration, appuio.io/active-deadline-seconds-override,\
-          \ test.appuio.io/*, compute.test.appuio.io/cpu.\nannotations given:\n  \
-          \  {{request.object.metadata.annotations}}.\nannotations before modification:\n\
-          \    {{request.oldObject.metadata.annotations}}."
+          \ kubectl.kubernetes.io/last-applied-configuration, policies.kyverno.io/last-applied-patches,\
+          \ appuio.io/active-deadline-seconds-override, test.appuio.io/*, compute.test.appuio.io/cpu.\n\
+          annotations given:\n    {{request.object.metadata.annotations}}.\nannotations\
+          \ before modification:\n    {{request.oldObject.metadata.annotations}}."
   validationFailureAction: enforce


### PR DESCRIPTION
If using mutate, Kyverno appends an annotation to debug the mutate patches.
The annotation is appended in the context of the original requestor.
Thus we have to whitelist the annotation or the later validation rejects the request.
This should be safe because:
- The annotation is only for debugging and not referenced elsewhere.
- The mutating policies are validated with a validation rule too.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
