### PR TITLE
Allow network policy labels to be edited by users

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -36,6 +36,9 @@ parameters:
         - kubernetes.io/metadata.name
       appuioUserDefined: custom.appuio.io/*
       appuioOrg: appuio.io/organization
+      # As defined in component-networkpolicy: https://github.com/projectsyn/component-networkpolicy/blob/master/class/defaults.yml
+      netPolNoDefaults: network-policies.syn.tools/no-defaults
+      netPolPurgeDefaults: network-policies.syn.tools/purge-defaults
 
     allowedNamespaceAnnotations:
       kubernetesGenerated:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
@@ -59,15 +59,19 @@ spec:
                   - key: '{{regex_match(`"^appuio.io/organization$"`, `"{{element.key}}"`)
                       || regex_match(`"^custom.appuio.io/.*$"`, `"{{element.key}}"`)
                       || regex_match(`"^kubernetes.io/metadata.name$"`, `"{{element.key}}"`)
-                      || regex_match(`"^test.appuio.io/.*$"`, `"{{element.key}}"`)
-                      || regex_match(`"^compute.test.appuio.io/cpu$"`, `"{{element.key}}"`)}}'
+                      || regex_match(`"^network-policies.syn.tools/no-defaults$"`,
+                      `"{{element.key}}"`) || regex_match(`"^network-policies.syn.tools/purge-defaults$"`,
+                      `"{{element.key}}"`) || regex_match(`"^test.appuio.io/.*$"`,
+                      `"{{element.key}}"`) || regex_match(`"^compute.test.appuio.io/cpu$"`,
+                      `"{{element.key}}"`)}}'
                     operator: Equals
                     value: false
             list: 'request.object&& merge(    not_null(request.object.metadata.labels,
               `{}`)   ,not_null(request.oldObject.metadata.labels, `{}`))  | map(&{key:
               @}, keys(@))'
         message: "The following labels can be modified:\n    appuio.io/organization,\
-          \ custom.appuio.io/*, kubernetes.io/metadata.name, test.appuio.io/*, compute.test.appuio.io/cpu.\n\
+          \ custom.appuio.io/*, kubernetes.io/metadata.name, network-policies.syn.tools/no-defaults,\
+          \ network-policies.syn.tools/purge-defaults, test.appuio.io/*, compute.test.appuio.io/cpu.\n\
           labels given:\n    {{request.object.metadata.labels}}.\nlabels before modification:\n\
           \    {{request.oldObject.metadata.labels}}."
     - exclude:


### PR DESCRIPTION
Allows to edit 
* `network-policies.syn.tools/no-defaults`
* `network-policies.syn.tools/purge-defaults`

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
