### PR TITLE
Update default terminating quota to match APPUiO Public

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -100,9 +100,11 @@ parameters:
         synchronize: true
         spec:
           hard:
-            limits.cpu: 1000m
-            limits.memory: 2Gi
+            limits.cpu: 4000m
+            limits.memory: 4Gi
             pods: "5"
+            requests.cpu: 500m
+            requests.memory: 2Gi
           scopes:
             - Terminating
 

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -77,11 +77,15 @@ spec:
           spec:
             hard:
               limits.cpu: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-compute-terminating.limits.cpu"
-                || ''1000m'' }}'
+                || ''4000m'' }}'
               limits.memory: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-compute-terminating.limits.memory"
-                || ''2Gi'' }}'
+                || ''4Gi'' }}'
               pods: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-compute-terminating.pods"
                 || ''5'' }}'
+              requests.cpu: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-compute-terminating.requests.cpu"
+                || ''500m'' }}'
+              requests.memory: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-compute-terminating.requests.memory"
+                || ''2Gi'' }}'
             scopes:
               - Terminating
         kind: ResourceQuota


### PR DESCRIPTION
See product `flexible:v6` in https://control.vshn.net/appuio/products/appuio%20public (internal) for the current terminating quota for new projects on APPUiO Public.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
