### PR TITLE
Allow user to delete namespaces he owns

### DIFF
--- a/component/generated-rolebindings.jsonnet
+++ b/component/generated-rolebindings.jsonnet
@@ -60,6 +60,7 @@ local generateDefaultRolebindingInNsPolicy = kyverno.ClusterPolicy('default-role
                   'watch',
                   'edit',
                   'patch',
+                  'delete',
                 ],
               },
             ],

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
@@ -45,6 +45,7 @@ spec:
                 - watch
                 - edit
                 - patch
+                - delete
         kind: Role
         name: namespace-owner
         namespace: '{{request.object.metadata.name}}'


### PR DESCRIPTION
By adding the permission to delete namespaces with a `RoleBinding` we only allow a user to delete the `Namespace` that contains the `RoleBinding`.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
