### PR TITLE
Unify default RoleBinding of namespaces and projects

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -54,7 +54,7 @@ parameters:
       kyvernoMutateLabel: policies.kyverno.io/last-applied-patches
 
     generatedDefaultRoleBindingInNewNamespaces:
-      bindingName: organization-admin
+      bindingName: admin
       clusterRoleName: admin
 
     generatedNamespaceOwnerRole:
@@ -130,7 +130,7 @@ parameters:
     disallowDockerBuildStrategy: true
 
     projectTemplate:
-      enabled: false
+      enabled: true
       objects:
         project:
           apiVersion: project.openshift.io/v1
@@ -141,6 +141,24 @@ parameters:
               openshift.io/display-name: '\${PROJECT_DISPLAYNAME}'
               openshift.io/requester: '\${PROJECT_REQUESTING_USER}'
             name: '\${PROJECT_NAME}'
+
+        adminRoleBinding:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            labels:
+              appuio.io/uninitialized: "true"
+            creationTimestamp: null
+            name: admin
+            namespace: '\${PROJECT_NAME}'
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: admin
+          subjects:
+            - apiGroup: rbac.authorization.k8s.io
+              kind: User
+              name: '\${PROJECT_ADMIN_USER}'
       parameters:
         PROJECT_NAME: {}
         PROJECT_DISPLAYNAME: {}

--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -54,6 +54,8 @@ local matchNamespaces(selector=null, names=null, match='all') = matchKinds(selec
 
 local matchProjectRequests(selector=null, names=null, match='all') = matchKinds(selector, names, match, kinds=[ 'ProjectRequest' ]);
 
+local matchRoleBindings(selector=null, names=null, match='all') = matchKinds(selector, names, match, kinds=[ 'rbac.authorization.k8s.io/v1/RoleBinding' ]);
+
 local matchOrgNamespaces = matchNamespaces(selector=orgLabelSelector);
 
 local kyvernoPatternToRegex = function(pattern)
@@ -66,5 +68,6 @@ local kyvernoPatternToRegex = function(pattern)
   MatchNamespaces: matchNamespaces,
   MatchOrgNamespaces: matchOrgNamespaces,
   MatchProjectRequests: matchProjectRequests,
+  MatchRoleBindings: matchRoleBindings,
   KyvernoPatternToRegex: kyvernoPatternToRegex,
 }

--- a/component/generated-rolebindings.jsonnet
+++ b/component/generated-rolebindings.jsonnet
@@ -69,14 +69,26 @@ local generateDefaultRolebindingInNsPolicy = kyverno.ClusterPolicy('default-role
           },
         ],
         mutate: {
-          patchesJson6902: |||
-            - op: add
-              path: "/subjects"
-              value: [{"apiGroup":"rbac.authorization.k8s.io","kind":"Group","name":"{{organization}}"}]
-              name: update-rolebinding
-            - op: remove
-              path: "/metadata/labels/appuio.io~1uninitialized"
-          |||,
+          patchesJson6902: std.manifestYamlDoc(
+            [
+              {
+                op: 'add',
+                path: '/subjects',
+                value: [
+                  {
+                    apiGroup: 'rbac.authorization.k8s.io',
+                    kind: 'Group',
+                    name: '{{organization}}',
+                  },
+                ],
+                name: 'update-rolebinding',
+              },
+              {
+                op: 'remove',
+                path: '/metadata/labels/appuio.io~1uninitialized',
+              },
+            ]
+          ),
         },
 
       },

--- a/component/generated-rolebindings.jsonnet
+++ b/component/generated-rolebindings.jsonnet
@@ -15,6 +15,15 @@ local params = inv.parameters.appuio_cloud;
   * - Also, the RoleBinding is mutable by the user.
   */
 local generateDefaultRolebindingInNsPolicy = kyverno.ClusterPolicy('default-rolebinding-in-ns') {
+  metadata+: {
+    annotations+: {
+      // Kyverno somehow detects this rule as needing controller autogeneration.
+      // https://kyverno.io/docs/writing-policies/autogen/
+      // Explicitly disable autogen. We don't need it here
+      // since only Namespaces and RoleBinding are matched.
+      'pod-policies.kyverno.io/autogen-controllers': 'none',
+    },
+  },
   spec: {
     rules: [
       {

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
@@ -50,10 +50,10 @@ spec:
                 matchLabels:
                   appuio.io/uninitialized: 'true'
       mutate:
-        patchesJson6902: "- op: add\n  path: \"/subjects\"\n  value: [{\"apiGroup\"\
-          :\"rbac.authorization.k8s.io\",\"kind\":\"Group\",\"name\":\"{{organization}}\"\
-          }]\n  name: update-rolebinding\n- op: remove\n  path: \"/metadata/labels/appuio.io~1uninitialized\"\
-          \n"
+        patchesJson6902: "- \"name\": \"update-rolebinding\"\n  \"op\": \"add\"\n\
+          \  \"path\": \"/subjects\"\n  \"value\":\n  - \"apiGroup\": \"rbac.authorization.k8s.io\"\
+          \n    \"kind\": \"Group\"\n    \"name\": \"{{organization}}\"\n- \"op\"\
+          : \"remove\"\n  \"path\": \"/metadata/labels/appuio.io~1uninitialized\""
       name: patch-uninitialized-default-rolebinding
     - generate:
         data:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
@@ -1,7 +1,8 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  annotations: {}
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
   labels:
     app.kubernetes.io/component: appuio-cloud
     app.kubernetes.io/managed-by: commodore

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
@@ -20,7 +20,7 @@ spec:
             - kind: Group
               name: '{{request.object.metadata.labels."appuio.io/organization"}}'
         kind: RoleBinding
-        name: organization-admin
+        name: admin
         namespace: '{{request.object.metadata.name}}'
         synchronize: false
       match:
@@ -33,6 +33,27 @@ spec:
                   - key: appuio.io/organization
                     operator: Exists
       name: default-rolebinding
+    - context:
+        - apiCall:
+            jmesPath: metadata.labels."appuio.io/organization"
+            urlPath: /api/v1/namespaces/{{request.object.metadata.namespace}}
+          name: organization
+      match:
+        all:
+          - resources:
+              kinds:
+                - rbac.authorization.k8s.io/v1/RoleBinding
+              names:
+                - admin
+              selector:
+                matchLabels:
+                  appuio.io/uninitialized: 'true'
+      mutate:
+        patchesJson6902: "- op: add\n  path: \"/subjects\"\n  value: [{\"apiGroup\"\
+          :\"rbac.authorization.k8s.io\",\"kind\":\"Group\",\"name\":\"{{organization}}\"\
+          }]\n  name: update-rolebinding\n- op: remove\n  path: \"/metadata/labels/appuio.io~1uninitialized\"\
+          \n"
+      name: patch-uninitialized-default-rolebinding
     - generate:
         data:
           rules:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/20_project_template.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/20_project_template.yaml
@@ -5,4 +5,46 @@ metadata:
   labels:
     name: cluster
   name: cluster
-spec: {}
+spec:
+  projectRequestTemplate:
+    name: project-request
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  annotations: {}
+  labels:
+    name: project-request
+  name: project-request
+  namespace: openshift-config
+objects:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        appuio.io/uninitialized: 'true'
+      name: admin
+      namespace: ${PROJECT_NAME}
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: admin
+    subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: User
+        name: ${PROJECT_ADMIN_USER}
+  - apiVersion: project.openshift.io/v1
+    kind: Project
+    metadata:
+      annotations:
+        openshift.io/description: ${PROJECT_DESCRIPTION}
+        openshift.io/display-name: ${PROJECT_DISPLAYNAME}
+        openshift.io/requester: ${PROJECT_REQUESTING_USER}
+      name: ${PROJECT_NAME}
+parameters:
+  - name: PROJECT_ADMIN_USER
+  - name: PROJECT_DESCRIPTION
+  - name: PROJECT_DISPLAYNAME
+  - name: PROJECT_NAME
+  - name: PROJECT_REQUESTING_USER

--- a/tests/kyverno/defaults/generate-default-rolebinding-in-ns-test.yaml
+++ b/tests/kyverno/defaults/generate-default-rolebinding-in-ns-test.yaml
@@ -1,0 +1,21 @@
+name: test default RoleBinding generation
+policies:
+  - compiled/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
+resources:
+  - generate-default-rolebinding-in-ns/uninit-rolebinding.yaml
+variables: generate-default-rolebinding-in-ns-variables.yaml
+results:
+  - policy: default-rolebinding-in-ns
+    rule: patch-uninitialized-default-rolebinding
+    resource: admin
+    namespace: org-namespace
+    kind: RoleBinding
+    result: skip
+    patchedResource: generate-default-rolebinding-in-ns/uninit-rolebinding-patched.yaml
+  - policy: default-rolebinding-in-ns
+    rule: patch-uninitialized-default-rolebinding
+    resource: admin
+    namespace: org-project
+    kind: RoleBinding
+    result: pass
+    patchedResource: generate-default-rolebinding-in-ns/uninit-rolebinding-patched.yaml

--- a/tests/kyverno/defaults/generate-default-rolebinding-in-ns-variables.yaml
+++ b/tests/kyverno/defaults/generate-default-rolebinding-in-ns-variables.yaml
@@ -1,0 +1,6 @@
+policies:
+  - name: default-rolebinding-in-ns
+    rules:
+      - name: patch-uninitialized-default-rolebinding
+        values:
+          organization: "purple-fox"

--- a/tests/kyverno/defaults/generate-default-rolebinding-in-ns/init-rolebinding.yaml
+++ b/tests/kyverno/defaults/generate-default-rolebinding-in-ns/init-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin
+  namespace: org-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: purple-fox

--- a/tests/kyverno/defaults/generate-default-rolebinding-in-ns/uninit-rolebinding-patched.yaml
+++ b/tests/kyverno/defaults/generate-default-rolebinding-in-ns/uninit-rolebinding-patched.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin
+  namespace: org-project
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: purple-fox

--- a/tests/kyverno/defaults/generate-default-rolebinding-in-ns/uninit-rolebinding.yaml
+++ b/tests/kyverno/defaults/generate-default-rolebinding-in-ns/uninit-rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin
+  namespace: org-project
+  labels:
+    appuio.io/uninitialized: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: fox


### PR DESCRIPTION
We do this by add a label to the `admin` rolebinding created by the
project template and modifying it through a mutating policy.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
