### PR TITLE
Raise default CPU requests and limits for NotTerminating resources

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -88,9 +88,9 @@ parameters:
         synchronize: true
         spec:
           hard:
-            requests.cpu: 1000m
+            requests.cpu: 4
             requests.memory: 4Gi
-            limits.cpu: 2
+            limits.cpu: 8
             limits.memory: 20Gi
             pods: "45"
           scopes:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -47,13 +47,13 @@ spec:
           spec:
             hard:
               limits.cpu: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-compute.limits.cpu"
-                || ''2'' }}'
+                || ''8'' }}'
               limits.memory: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-compute.limits.memory"
                 || ''20Gi'' }}'
               pods: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-compute.pods"
                 || ''45'' }}'
               requests.cpu: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-compute.requests.cpu"
-                || ''1000m'' }}'
+                || ''4'' }}'
               requests.memory: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-compute.requests.memory"
                 || ''4Gi'' }}'
             scopes:


### PR DESCRIPTION
The default CPU limit was way too low, even for a simple application with a few Pods.

## Checklist

- [X] PR contains a single logical change (to build a better changelog).
- [X] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
