### PR TITLE
Don't use wildcard in excluded cluster roles for Kyverno policies

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -17,7 +17,11 @@ parameters:
         syn-admin: syn-admin
         syn-argocd-application-controller: syn-argocd-application-controller
         syn-argocd-server: syn-argocd-server
-        syn-resource-locker-*: syn-resource-locker-*
+        syn-resource-locker:
+          # Created by openshift4-ingress
+          - syn-resource-locker-namespace-default-manager
+          # Created by openshift4-monitoring
+          - syn-resource-locker-namespace-openshift-monitoring-manager
         system:controller:generic-garbage-collector: system:controller:generic-garbage-collector
         system:controller:operator-lifecycle-manager: system:controller:operator-lifecycle-manager
         system:master: system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
@@ -24,7 +24,8 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-*
+          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-openshift-monitoring-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -29,7 +29,8 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-*
+          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-openshift-monitoring-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -82,7 +83,8 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-*
+          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-openshift-monitoring-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -117,7 +119,8 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-*
+          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-openshift-monitoring-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
@@ -25,7 +25,8 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-*
+          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-openshift-monitoring-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -87,7 +88,8 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-*
+          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-openshift-monitoring-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
@@ -29,7 +29,8 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-*
+          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-openshift-monitoring-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/12_namespace_quota_per_zone.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/12_namespace_quota_per_zone.yaml
@@ -36,7 +36,8 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-*
+          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-openshift-monitoring-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -100,7 +101,8 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-*
+          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-openshift-monitoring-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master


### PR DESCRIPTION
It turns out that Kyverno doesn't support wildcards for specifying excluded or matching cluster roles for policies.

As a short term workaround, we replace the wildcard cluster role with a list of all the clusterroles the wildcard would expand to on APPUiO Cloud.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
