### PR TITLE
Refactor ProjectRequest rules into one policy

### DIFF
--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -51,25 +51,6 @@ spec:
             labels:
               +(appuio.io/organization): '{{ocpuser.metadata.annotations."appuio.io/default-organization"}}'
       name: set-default-organization-ns
-    - context:
-        - apiCall:
-            jmesPath: '@'
-            urlPath: /apis/user.openshift.io/v1/users/{{request.object.metadata.annotations."openshift.io/requester"}}
-          name: ocpuser
-      exclude: {}
-      match:
-        all:
-          - resources:
-              annotations:
-                openshift.io/requester: ?*
-              kinds:
-                - Project
-      mutate:
-        patchStrategicMerge:
-          metadata:
-            labels:
-              +(appuio.io/organization): '{{ocpuser.metadata.annotations."appuio.io/default-organization"}}'
-      name: set-default-organization-project
     - exclude:
         clusterRoles:
           - cluster-admin

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
@@ -45,11 +45,46 @@ spec:
           - resources:
               kinds:
                 - ProjectRequest
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              +(appuio.io/organization): '{{ocpuser.metadata.annotations."appuio.io/default-organization"}}'
+      name: set-default-organization
+    - exclude:
+        clusterRoles:
+          - cluster-admin
+          - cluster-image-registry-operator
+          - cluster-node-tuning-operator
+          - kyverno:generatecontroller
+          - kyverno:policycontroller
+          - multus-admission-controller-webhook
+          - openshift-dns-operator
+          - openshift-ingress-operator
+          - syn-admin
+          - syn-argocd-application-controller
+          - syn-argocd-server
+          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-openshift-monitoring-manager
+          - system:controller:generic-garbage-collector
+          - system:controller:operator-lifecycle-manager
+          - system:master
+          - system:openshift:controller:namespace-security-allocation-controller
+        roles: []
+        subjects:
+          - kind: ServiceAccount
+            name: argocd-application-controller
+            namespace: argocd
+      match:
+        all:
+          - resources:
+              kinds:
+                - ProjectRequest
       name: user-has-default-organization
       validate:
         deny:
           conditions:
-            - key: '{{ocpuser.metadata.annotations."appuio.io/default-organization"}}'
+            - key: '{{request.object.metadata.labels."appuio.io/organization"}}'
               operator: Equals
               value: ''
         message: You cannot create Projects without belonging to an organization


### PR DESCRIPTION
Separating namespace and project rules IMO makes them easier to reason about (and extend the namespace policy I'm working on)
## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
