### PR TITLE
Allow Service Accounts to create namespaces

### DIFF
--- a/component/namespace-policies.jsonnet
+++ b/component/namespace-policies.jsonnet
@@ -40,6 +40,10 @@ local appuioNsProvisionersRoleBinding = kube.ClusterRoleBinding('appuio-ns-provi
       kind: 'Group',
       name: 'system:authenticated:oauth',
     },
+    {
+      kind: 'Group',
+      name: 'system:serviceaccounts',
+    },
   ],
 };
 

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_appuio_ns_provisioners_crb.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_appuio_ns_provisioners_crb.yaml
@@ -15,3 +15,5 @@ roleRef:
 subjects:
   - kind: Group
     name: system:authenticated:oauth
+  - kind: Group
+    name: system:serviceaccounts


### PR DESCRIPTION
We actually need to allow service accounts to create namespaces. Otherwise https://github.com/appuio/component-appuio-cloud/pull/55 is fairly useless.

Any service account should be in group `system:serviceaccounts` according to https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
