### PR TITLE
Change namespace-owner config to use a ClusterRole

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -61,7 +61,7 @@ parameters:
       bindingName: admin
       clusterRoleName: admin
 
-    generatedNamespaceOwnerRole:
+    generatedNamespaceOwnerClusterRole:
       name: namespace-owner
 
     maxNamespaceQuota: 25

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -128,13 +128,13 @@ default:: `organization-admin`
 The `metadata.name` of the `RoleBinding` that gets generated in the new `Namespace` created by the user.
 The role binding is only created upon Namespace creation, it doesn't get synchronized.
 
-== `generatedNamespaceOwnerRole.name`
+== `generatedNamespaceOwnerClusterRole.name`
 
 [horizontal]
 type:: string
 default:: `namespace-owner`
 
-The `Role` and `RoleBinding` name for the role that allows users to edit the new `Namespace`
+The `ClusterRole` and `RoleBinding` name for the cluster role that allows users to edit the new `Namespace`
 
 == `generatedResourceQuota`
 

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_generate_default_rolebinding_in_ns.yaml
@@ -57,36 +57,9 @@ spec:
       name: patch-uninitialized-default-rolebinding
     - generate:
         data:
-          rules:
-            - apiGroups:
-                - ''
-              resources:
-                - namespaces
-              verbs:
-                - get
-                - watch
-                - edit
-                - patch
-                - delete
-        kind: Role
-        name: namespace-owner
-        namespace: '{{request.object.metadata.name}}'
-        synchronize: false
-      match:
-        all:
-          - resources:
-              kinds:
-                - Namespace
-              selector:
-                matchExpressions:
-                  - key: appuio.io/organization
-                    operator: Exists
-      name: namespace-edit-role
-    - generate:
-        data:
           roleRef:
             apiGroup: rbac.authorization.k8s.io
-            kind: Role
+            kind: ClusterRole
             name: namespace-owner
           subjects:
             - kind: Group

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_namespace_editor_clusterrole.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_namespace_editor_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: appuio-cloud
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud
+    name: namespace-owner
+  name: namespace-owner
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - watch
+      - edit
+      - patch
+      - delete


### PR DESCRIPTION
Create a single cluster role `namespace-owner` instead of creating a role `namespace-owner` in each organization namespace and create a role binding called `namespace-owner` granting the clusterrole to the namespace's organization's group.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
