### PR TITLE
Add support to skip adding `activeDeadlineSeconds` to "run-once" pods based on their labels

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -170,3 +170,4 @@ parameters:
     runOnceActiveDeadlineSeconds:
       defaultActiveDeadlineSeconds: 1800
       overrideAnnotationKey: appuio.io/active-deadline-seconds-override
+      podMatchExpressions: {}

--- a/component/runonce-activedeadlineseconds.jsonnet
+++ b/component/runonce-activedeadlineseconds.jsonnet
@@ -17,6 +17,14 @@ local jmesPath =
     defaultDeadline,
   ];
 
+local matchExprs = std.prune([
+  if config.podMatchExpressions[name] != null then
+    {
+      key: name,
+    } + config.podMatchExpressions[name]
+  for name in std.objectFields(config.podMatchExpressions)
+]);
+
 local policy =
   kyverno.ClusterPolicy('set-runonce-activedeadlineseconds') {
     metadata+: {
@@ -52,6 +60,9 @@ local policy =
               kinds: [
                 'Pod',
               ],
+              [if std.length(matchExprs) > 0 then 'selector']: {
+                matchExpressions: matchExprs,
+              },
             },
           },
           mutate: {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -361,3 +361,16 @@ type:: string
 default:: `appuio.io/active-deadline-seconds-override`
 
 The key of the namespace annotation which users can use to override the global default value for `.spec.activeDeadlineSeconds`.
+
+=== `runOnceActiveDeadlineSeconds.podMatchExpressions`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+The entries of the dict are expected to be of form `labelKey: <partial matchExpression>`.
+Each entry is transformed to a Kubernetes `matchExpression` entry by taking the key as value for field `name` of the resulting match expression.
+
+See the `matchExpressions` section in the https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/label-selector/#LabelSelector[Kubernetes LabelSelector] documentation for supported fields in a `matchExpressions` element.
+
+The field `activeDeadlineSeconds` will only be set for pods which match the provided expressions.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -367,10 +367,22 @@ The key of the namespace annotation which users can use to override the global d
 [horizontal]
 type:: dict
 default:: `{}`
+example::
++
+[source,yaml]
+----
+podMatchExpressions:
+  # Don't set activeDeadlineSeconds for pods which have
+  # label `acme.cert-manager.io/http01-solver`
+  acme.cert-manager.io/http01-solver:
+    operator: DoesNotExist
+----
 
 The entries of the dict are expected to be of form `labelKey: <partial matchExpression>`.
-Each entry is transformed to a Kubernetes `matchExpression` entry by taking the key as value for field `name` of the resulting match expression.
+Each entry is transformed to a Kubernetes `matchExpression` entry by taking the key as value for field `key` of the resulting match expression.
 
 See the `matchExpressions` section in the https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/label-selector/#LabelSelector[Kubernetes LabelSelector] documentation for supported fields in a `matchExpressions` element.
 
 The field `activeDeadlineSeconds` will only be set for pods which match the provided expressions.
+
+Generally, we recommend adjusting the value for `activeDeadlineSeconds` by annotating namespaces as documented above or by setting `activeDeadlineSeconds` in the Pod spec, but in some cases it may be necessary to exclude pods from the policy.

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -33,5 +33,11 @@ parameters:
         - test.appuio.io/*
         - compute.test.appuio.io/cpu
 
+    runOnceActiveDeadlineSeconds:
+      podMatchExpressions:
+        acme.cert-manager.io/http01-solver:
+          operator: DoesNotExist
+        another: null
+
   resource_locker:
     namespace: syn-resource-locker

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/30_set_runonce_activedeadlineseconds.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/30_set_runonce_activedeadlineseconds.yaml
@@ -27,6 +27,10 @@ spec:
         resources:
           kinds:
             - Pod
+          selector:
+            matchExpressions:
+              - key: acme.cert-manager.io/http01-solver
+                operator: DoesNotExist
       mutate:
         patchStrategicMerge:
           spec:

--- a/tests/kyverno/defaults/set-runonce-activedeadlineseconds-test.yaml
+++ b/tests/kyverno/defaults/set-runonce-activedeadlineseconds-test.yaml
@@ -1,0 +1,37 @@
+name: test run-once activedeadline seconds injection
+policies:
+  - compiled/appuio-cloud/appuio-cloud/30_set_runonce_activedeadlineseconds.yaml
+resources:
+  - set-runonce-activedeadlineseconds/managed-pod.yaml
+  - set-runonce-activedeadlineseconds/existing-deadline-pod.yaml
+  - set-runonce-activedeadlineseconds/cm-http01-pod.yaml
+  - set-runonce-activedeadlineseconds/eligible-pod.yaml
+variables: set-runonce-activedeadlineseconds-variables.yaml
+# NOTE: We specify `patchedResource` for all test cases, even though it's not
+# used for the cases with `result=skip`. This ensures that we get nice errors
+# if a resource is not skipped even though it should be.
+results:
+  - policy: set-runonce-activedeadlineseconds
+    rule: set-runonce-activedeadlineseconds
+    resource: managed-pod
+    patchedResource: set-runonce-activedeadlineseconds/managed-pod.yaml
+    kind: Pod
+    result: skip
+  - policy: set-runonce-activedeadlineseconds
+    rule: set-runonce-activedeadlineseconds
+    resource: existing-deadline-pod
+    patchedResource: set-runonce-activedeadlineseconds/existing-deadline-pod.yaml
+    kind: Pod
+    result: skip
+  - policy: set-runonce-activedeadlineseconds
+    rule: set-runonce-activedeadlineseconds
+    resource: cm-http01-pod
+    patchedResource: set-runonce-activedeadlineseconds/cm-http01-pod.yaml
+    kind: Pod
+    result: skip
+  - policy: set-runonce-activedeadlineseconds
+    rule: set-runonce-activedeadlineseconds
+    resource: eligible-pod
+    patchedResource: set-runonce-activedeadlineseconds/eligible-pod-deadlineseconds.yaml
+    kind: Pod
+    result: pass

--- a/tests/kyverno/defaults/set-runonce-activedeadlineseconds-variables.yaml
+++ b/tests/kyverno/defaults/set-runonce-activedeadlineseconds-variables.yaml
@@ -1,0 +1,10 @@
+globalValues:
+  request.operation: CREATE
+
+policies:
+  - name: set-runonce-activedeadlineseconds
+    rules:
+      - name: set-runonce-activedeadlineseconds
+        values:
+          activeDeadlineSeconds: '1800'
+          request.namespace: test-ns

--- a/tests/kyverno/defaults/set-runonce-activedeadlineseconds/cm-http01-pod.yaml
+++ b/tests/kyverno/defaults/set-runonce-activedeadlineseconds/cm-http01-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cm-http01-pod
+  labels:
+    acme.cert-manager.io/http01-solver: "true"
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: shell
+      image: ubuntu
+      command: ['/bin/sh', '-c', 'trap : TERM INT; sleep infinity & wait']

--- a/tests/kyverno/defaults/set-runonce-activedeadlineseconds/eligible-pod-deadlineseconds.yaml
+++ b/tests/kyverno/defaults/set-runonce-activedeadlineseconds/eligible-pod-deadlineseconds.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: eligible-pod
+spec:
+  activeDeadlineSeconds: 1800
+  restartPolicy: OnFailure
+  containers:
+    - name: shell
+      image: ubuntu
+      command: ['/bin/sh', '-c', 'trap : TERM INT; sleep infinity & wait']

--- a/tests/kyverno/defaults/set-runonce-activedeadlineseconds/eligible-pod.yaml
+++ b/tests/kyverno/defaults/set-runonce-activedeadlineseconds/eligible-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: eligible-pod
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: shell
+      image: ubuntu
+      command: ['/bin/sh', '-c', 'trap : TERM INT; sleep infinity & wait']

--- a/tests/kyverno/defaults/set-runonce-activedeadlineseconds/existing-deadline-pod.yaml
+++ b/tests/kyverno/defaults/set-runonce-activedeadlineseconds/existing-deadline-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: existing-deadline-pod
+spec:
+  activeDeadlineSeconds: 86400
+  restartPolicy: OnFailure
+  containers:
+    - name: shell
+      image: ubuntu
+      command: ['/bin/sh', '-c', 'trap : TERM INT; sleep infinity & wait']

--- a/tests/kyverno/defaults/set-runonce-activedeadlineseconds/managed-pod.yaml
+++ b/tests/kyverno/defaults/set-runonce-activedeadlineseconds/managed-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: managed-pod
+spec:
+  restartPolicy: Always
+  containers:
+    - name: shell
+      image: ubuntu
+      command: ['/bin/sh', '-c', 'trap : TERM INT; sleep infinity & wait']


### PR DESCRIPTION
This PR introduces support for not adding `activeDeadlineSeconds` to "run-once" pods based on their labels.

This can be useful to exclude some pods (e.g. cert-manager http01 solver pods) from the default deadline logic.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
