### PR TITLE
Kyverno policy renderer: extract policy types from parsed policies

### DIFF
--- a/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
@@ -10,7 +10,7 @@ Disallow creation and editing of reserved namespaces
 Category:: Namespace Ownership
 Minimum Kyverno version:: v1
 Subject:: APPUiO Organizations
-Policy type:: "generate"
+Policy types:: `validate`
 Implementation:: https://github.com/appuio/component-appuio-cloud/tree/master/component/namespace-policies.jsonnet[component/namespace-policies.jsonnet]
 
 This policy will:

--- a/docs/modules/ROOT/pages/references/policies/02_organization_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_namespaces.adoc
@@ -10,7 +10,7 @@ Ensure that all namespaces created by users have a label `appuio.io/organization
 Category:: Namespace Ownership
 Minimum Kyverno version:: v1
 Subject:: APPUiO Organizations
-Policy type:: "generate"
+Policy types:: `mutate`, `validate`
 Implementation:: https://github.com/appuio/component-appuio-cloud/tree/master/component/namespace-policies.jsonnet[component/namespace-policies.jsonnet]
 
 This policy will:

--- a/docs/modules/ROOT/pages/references/policies/02_organization_projects.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_projects.adoc
@@ -10,7 +10,7 @@ Ensure that all OpenShift Projects created by users have a label `appuio.io/orga
 Category:: Namespace Ownership
 Minimum Kyverno version:: v1
 Subject:: APPUiO Organizations
-Policy type:: "mutate"
+Policy types:: `mutate`
 Implementation:: https://github.com/appuio/component-appuio-cloud/tree/master/component/namespace-policies.jsonnet[component/namespace-policies.jsonnet]
 
 This policy will:

--- a/docs/modules/ROOT/pages/references/policies/02_organization_sa_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_sa_namespaces.adoc
@@ -10,7 +10,7 @@ Ensure that all namespaces created by organization serviceaccounts have a label 
 Category:: Namespace Ownership
 Minimum Kyverno version:: v1
 Subject:: APPUiO Organizations
-Policy type:: "generate"
+Policy types:: `mutate`, `validate`
 Implementation:: https://github.com/appuio/component-appuio-cloud/tree/master/component/namespace-policies.jsonnet[component/namespace-policies.jsonnet]
 
 This policy will:

--- a/docs/modules/ROOT/pages/references/policies/02_validate_namespace_metadata.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_validate_namespace_metadata.adoc
@@ -10,7 +10,7 @@ Disallow auxiliary labels and annotations
 Category:: Namespace Ownership
 Minimum Kyverno version:: v1
 Subject:: APPUiO Organizations
-Policy type:: "generate"
+Policy types:: `validate`
 Implementation:: https://github.com/appuio/component-appuio-cloud/tree/master/component/namespace-policies.jsonnet[component/namespace-policies.jsonnet]
 
 This policy will:

--- a/docs/modules/ROOT/pages/references/policies/03_projectrequest.adoc
+++ b/docs/modules/ROOT/pages/references/policies/03_projectrequest.adoc
@@ -10,7 +10,7 @@ Check the requesting user's default organization for OpenShift ProjectRequests.
 Category:: Namespace Ownership
 Minimum Kyverno version:: v1
 Subject:: APPUiO Organizations
-Policy type:: "generate"
+Policy types:: `validate`
 Implementation:: https://github.com/appuio/component-appuio-cloud/tree/master/component/project-policies.jsonnet[component/project-policies.jsonnet]
 
 This policy will check that the requesting user has the `appuio.io/default-organization` annotation.

--- a/docs/modules/ROOT/pages/references/policies/10_generate_default_rolebinding_in_ns.adoc
+++ b/docs/modules/ROOT/pages/references/policies/10_generate_default_rolebinding_in_ns.adoc
@@ -10,7 +10,7 @@ Create default namespace ownership RoleBinding
 Category:: Access Control
 Minimum Kyverno version:: v1
 Subject:: rbac
-Policy type:: "generate"
+Policy types:: `generate`, `mutate`
 Implementation:: https://github.com/appuio/component-appuio-cloud/tree/master/component/generated-rolebindings.jsonnet[component/generated-rolebindings.jsonnet]
 
 This policy will:

--- a/docs/modules/ROOT/pages/references/policies/11_generate_quota_limit_range_in_ns.adoc
+++ b/docs/modules/ROOT/pages/references/policies/11_generate_quota_limit_range_in_ns.adoc
@@ -10,7 +10,7 @@ Create ResourceQuota and LimitRange objects in organization namespaces.
 Category:: Resource Quota
 Minimum Kyverno version:: v1
 Subject:: APPUiO Organizations
-Policy type:: "generate"
+Policy types:: `generate`
 Implementation:: https://github.com/appuio/component-appuio-cloud/tree/master/component/quota-limitrange.jsonnet[component/quota-limitrange.jsonnet]
 
 This policy generates `ResourceQuota` and `LimitRange` objects in namespaces which have the `appuio.io/organization` label.

--- a/docs/modules/ROOT/pages/references/policies/12_namespace_quota_per_zone.adoc
+++ b/docs/modules/ROOT/pages/references/policies/12_namespace_quota_per_zone.adoc
@@ -10,7 +10,7 @@ Check and enforce namespace quotas for organizations
 Category:: Namespace Management
 Minimum Kyverno version:: v1
 Subject:: APPUiO Organizations
-Policy type:: "generate"
+Policy types:: `validate`
 Implementation:: https://github.com/appuio/component-appuio-cloud/tree/master/component/namespace-quota.jsonnet[component/namespace-quota.jsonnet]
 
 This policy will deny creation of the new namespace if the number of existing namespaces for the requester's organization is greater or equal a certain number.

--- a/docs/modules/ROOT/pages/references/policies/30_set_runonce_activedeadlineseconds.adoc
+++ b/docs/modules/ROOT/pages/references/policies/30_set_runonce_activedeadlineseconds.adoc
@@ -10,7 +10,7 @@ Set `activeDeadlineSeconds` for run-once pods.
 Category:: Resource Quota
 Minimum Kyverno version:: v1
 Subject:: APPUiO Organizations
-Policy type:: "mutate"
+Policy types:: `mutate`
 Implementation:: https://github.com/appuio/component-appuio-cloud/tree/master/component/runonce-activedeadlineseconds.jsonnet[component/runonce-activedeadlineseconds.jsonnet]
 
 This policy ensures that all "runonce" pods have `.spec.activeDeadlineSeconds` set.

--- a/tools/render/templates/policy.adoc
+++ b/tools/render/templates/policy.adoc
@@ -13,7 +13,7 @@
 Category:: {{ index $annotations "policies.kyverno.io/category" }}
 Minimum Kyverno version:: {{ index $annotations "policies.kyverno.io/minversion" }}
 Subject:: {{ index $annotations "policies.kyverno.io/subject" }}
-Policy type:: "{{ .Type }}"
+Policy types:: {{ range $i, $e := .Types }}{{ if $i }}, {{end}}`{{ $e }}`{{ end }}
 Implementation:: {{ .BaseURL }}/{{ $jsonnet }}[{{ $jsonnet }}]
 
 {{ index $annotations "policies.kyverno.io/description" }}


### PR DESCRIPTION
The policy renderer doesn't actually check what the policy does to determine if it's a "mutate", "generate", or "validate" policy, it just does a string match on the policy YAML for each of those words and returns the first one it finds as the policy type.

Previously the code searched "generate", "mutate", "validate" without any fencing.  Since our excludes contain the string "validate" a lot of policies were mislabeled.

This commit changes the implementation to instead go through the rules on the parsed `kyvernov1.ClusterPolicy` object and identify all rule types present in the policy.

Follow-up for #62 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
