### PR TITLE
Deny `ProjectRequests` which match a disallowed name pattern

### DIFF
--- a/component/common.libsonnet
+++ b/component/common.libsonnet
@@ -58,6 +58,9 @@ local matchRoleBindings(selector=null, names=null, match='all') = matchKinds(sel
 
 local matchOrgNamespaces = matchNamespaces(selector=orgLabelSelector);
 
+local matchNamespacesAndProjectRequests(selector=null, names=null, match='all') =
+  matchKinds(selector, names, match, kinds=[ 'Namespace', 'ProjectRequest' ]);
+
 local kyvernoPatternToRegex = function(pattern)
   '^%s$' % std.strReplace(std.strReplace(pattern, '?', '.'), '*', '.*');
 
@@ -71,6 +74,7 @@ local jsonnetFile(filename) =
   FlattenSet: flattenSet,
   BypassNamespaceRestrictionsSubjects: bypassNamespaceRestrictionsSubjects,
   MatchNamespaces: matchNamespaces,
+  MatchNamespacesAndProjectRequests: matchNamespacesAndProjectRequests,
   MatchOrgNamespaces: matchOrgNamespaces,
   MatchProjectRequests: matchProjectRequests,
   MatchRoleBindings: matchRoleBindings,

--- a/component/namespace-policies.jsonnet
+++ b/component/namespace-policies.jsonnet
@@ -373,6 +373,8 @@ local disallowReservedNamespaces = kyverno.ClusterPolicy('disallow-reserved-name
         - Check if the requesting user/serviceaccount has a cluster role that allows them to create reserved namespaces.
 
         If the namespace matches a disallowed pattern and the requester doesn't have a cluster role which allows them to bypass the policy, the request is denied.
+        The policy is applied for requests to create `Namespace` and `ProjectRequest` resources.
+        This ensures that unprivileged users can't use disallowed patterns regardless of whether they use `oc new-project`, `kubectl create ns` or the OpenShift web console.
 
         The list of reserved namespace patterns is configured with xref:references/parameters#_reservednamespaces[component parameter `reservedNamespaces`].
 
@@ -386,7 +388,7 @@ local disallowReservedNamespaces = kyverno.ClusterPolicy('disallow-reserved-name
     rules: [
       {
         name: 'disallow-reserved-namespaces',
-        match: common.MatchNamespaces(
+        match: common.MatchNamespacesAndProjectRequests(
           names=common.FlattenSet(params.reservedNamespaces),
         ),
         exclude: common.BypassNamespaceRestrictionsSubjects(),

--- a/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
@@ -19,6 +19,8 @@ This policy will:
 - Check if the requesting user/serviceaccount has a cluster role that allows them to create reserved namespaces.
 
 If the namespace matches a disallowed pattern and the requester doesn't have a cluster role which allows them to bypass the policy, the request is denied.
+The policy is applied for requests to create `Namespace` and `ProjectRequest` resources.
+This ensures that unprivileged users can't use disallowed patterns regardless of whether they use `oc new-project`, `kubectl create ns` or the OpenShift web console.
 
 The list of reserved namespace patterns is configured with xref:references/parameters#_reservednamespaces[component parameter `reservedNamespaces`].
 
@@ -47,6 +49,13 @@ metadata:
 
       If the namespace matches a disallowed pattern and the requester doesn''t have
       a cluster role which allows them to bypass the policy, the request is denied.
+
+      The policy is applied for requests to create `Namespace` and `ProjectRequest`
+      resources.
+
+      This ensures that unprivileged users can''t use disallowed patterns regardless
+      of whether they use `oc new-project`, `kubectl create ns` or the OpenShift web
+      console.
 
 
       The list of reserved namespace patterns is configured with xref:references/parameters#_reservednamespaces[component
@@ -99,6 +108,7 @@ spec:
           - resources:
               kinds:
                 - Namespace
+                - ProjectRequest
               names:
                 - appuio-*
                 - cilium*

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
@@ -16,6 +16,13 @@ metadata:
       If the namespace matches a disallowed pattern and the requester doesn''t have
       a cluster role which allows them to bypass the policy, the request is denied.
 
+      The policy is applied for requests to create `Namespace` and `ProjectRequest`
+      resources.
+
+      This ensures that unprivileged users can''t use disallowed patterns regardless
+      of whether they use `oc new-project`, `kubectl create ns` or the OpenShift web
+      console.
+
 
       The list of reserved namespace patterns is configured with xref:references/parameters#_reservednamespaces[component
       parameter `reservedNamespaces`].
@@ -67,6 +74,7 @@ spec:
           - resources:
               kinds:
                 - Namespace
+                - ProjectRequest
               names:
                 - appuio-*
                 - cilium*


### PR DESCRIPTION
Previously, users could create namespaces matching a disallowed pattern with `oc new-project`.

Discovered while writing the documentation for #63 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
