### PR TITLE
Adjust default limitrange requests ratio

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -151,7 +151,7 @@ parameters:
             cpu: "600m"
             memory: "768Mi"
           defaultRequest:
-            cpu: "25m"
+            cpu: "10m"
             memory: "100Mi"
 
     disallowDockerBuildStrategy: true

--- a/docs/modules/ROOT/pages/references/policies/11_generate_quota_limit_range_in_ns.adoc
+++ b/docs/modules/ROOT/pages/references/policies/11_generate_quota_limit_range_in_ns.adoc
@@ -73,7 +73,7 @@ spec:
                   cpu: 600m
                   memory: 768Mi
                 defaultRequest:
-                  cpu: 25m
+                  cpu: 10m
                   memory: 100Mi
                 min:
                   cpu: 10m

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -44,7 +44,7 @@ spec:
                   cpu: 600m
                   memory: 768Mi
                 defaultRequest:
-                  cpu: 25m
+                  cpu: 10m
                   memory: 100Mi
                 min:
                   cpu: 10m


### PR DESCRIPTION
The component uses a default memory-per-core ratio of 4Gi. This commit adjusts the default limitrange requests to match that ratio.

Note that 25m / 100Mi doesn't exactly match the 4Gi/core ratio, even though the values appear to have a ratio of 1:4.

Instead of adjusting the memory requests to 102.4Mi to match the default ratio exactly, we go with 10m / 100Mi for the default requests.

This should be a good default, since most applications really don't need a lot of CPU when they're idle, and we leave the default limit at 600m / 768 Mi, so standard bursty workloads which don't have to serve hundreds of queries per second should be completely fine with the new default requests.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update documentation
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
