### PR TITLE
Add storage quotas for Rook-Ceph-backed storageclasses

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -114,6 +114,11 @@ parameters:
             requests.ephemeral-storage: "250Mi"
             limits.ephemeral-storage: "500Mi"
 
+            # Limit the total amount of Rook-Ceph backed storage which can be
+            # requested per namespace
+            cephfs-fspool-cluster.storageclass.storage.k8s.io/requests.storage: 25Gi
+            rbd-storagepool-cluster.storageclass.storage.k8s.io/requests.storage: 25Gi
+
       organization-compute:
         synchronize: true
         spec:

--- a/docs/modules/ROOT/pages/references/policies/11_generate_quota_limit_range_in_ns.adoc
+++ b/docs/modules/ROOT/pages/references/policies/11_generate_quota_limit_range_in_ns.adoc
@@ -158,6 +158,9 @@ spec:
         data:
           spec:
             hard:
+              cephfs-fspool-cluster.storageclass.storage.k8s.io/requests.storage: '{{
+                request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.cephfs-fspool-cluster.storageclass.storage.k8s.io_requests.storage"
+                || ''25Gi'' }}'
               count/configmaps: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_configmaps"
                 || ''150'' }}'
               count/replicationcontrollers: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_replicationcontrollers"
@@ -181,6 +184,9 @@ spec:
                 || ''50'' }}'
               persistentvolumeclaims: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.persistentvolumeclaims"
                 || ''10'' }}'
+              rbd-storagepool-cluster.storageclass.storage.k8s.io/requests.storage: '{{
+                request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.rbd-storagepool-cluster.storageclass.storage.k8s.io_requests.storage"
+                || ''25Gi'' }}'
               requests.ephemeral-storage: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.requests.ephemeral-storage"
                 || ''250Mi'' }}'
               requests.storage: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.requests.storage"

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -129,6 +129,9 @@ spec:
         data:
           spec:
             hard:
+              cephfs-fspool-cluster.storageclass.storage.k8s.io/requests.storage: '{{
+                request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.cephfs-fspool-cluster.storageclass.storage.k8s.io_requests.storage"
+                || ''25Gi'' }}'
               count/configmaps: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_configmaps"
                 || ''150'' }}'
               count/replicationcontrollers: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_replicationcontrollers"
@@ -152,6 +155,9 @@ spec:
                 || ''50'' }}'
               persistentvolumeclaims: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.persistentvolumeclaims"
                 || ''10'' }}'
+              rbd-storagepool-cluster.storageclass.storage.k8s.io/requests.storage: '{{
+                request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.rbd-storagepool-cluster.storageclass.storage.k8s.io_requests.storage"
+                || ''25Gi'' }}'
               requests.ephemeral-storage: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.requests.ephemeral-storage"
                 || ''250Mi'' }}'
               requests.storage: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.requests.storage"


### PR DESCRIPTION
We want to have fairly strict quotas for storageclasses backed by Rook-Ceph. This ensures that a single new PVC can't fill up the Ceph cluster to the point where it goes into read-only mode to protect itself from becoming so full that it can't be rebalanced anymore.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
