### PR TITLE
Add support for overriding storageclass-specific quotas

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -266,6 +266,12 @@ For example `resourcequota.appuio.io/organization-compute.limits.cpu: "1337"` wi
 
 For resources containing a forward slash, you will need to substitute it for an underline.
 For example: `resourcequota.appuio.io/organization-objects.openshift.io_imagestreams: "40"`.
+
+The exception is that for customizing storage class quotas you need to set annotation `resourcequota.appuio.io/<name>.storageclasses`.
+This is because the regular annotations for storageclass-specific resources are generally too long to be accepted as annotation keys by Kubernetes.
+The value of the `resourcequota.appuio.io/<name>.storageclasses` annotation is parsed as JSON by Kyverno.
+The policy expects that the parsed JSON is a single object.
+For quota keys of the resource quota `<name>` which match the prefix `<storageclass>.storageclass.storage.k8s.io` the policy checks that JSON object instead of a plain annotation for overrides.
 ====
 
 == `generatedLimitRange`

--- a/docs/modules/ROOT/pages/references/policies/11_generate_quota_limit_range_in_ns.adoc
+++ b/docs/modules/ROOT/pages/references/policies/11_generate_quota_limit_range_in_ns.adoc
@@ -159,7 +159,8 @@ spec:
           spec:
             hard:
               cephfs-fspool-cluster.storageclass.storage.k8s.io/requests.storage: '{{
-                request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.cephfs-fspool-cluster.storageclass.storage.k8s.io_requests.storage"
+                parse_json(request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.storageclasses"
+                || ''{}'')."cephfs-fspool-cluster.storageclass.storage.k8s.io/requests.storage"
                 || ''25Gi'' }}'
               count/configmaps: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_configmaps"
                 || ''150'' }}'
@@ -176,7 +177,8 @@ spec:
               limits.ephemeral-storage: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.limits.ephemeral-storage"
                 || ''500Mi'' }}'
               localblock-storage.storageclass.storage.k8s.io/persistentvolumeclaims: '{{
-                request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.localblock-storage.storageclass.storage.k8s.io_persistentvolumeclaims"
+                parse_json(request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.storageclasses"
+                || ''{}'')."localblock-storage.storageclass.storage.k8s.io/persistentvolumeclaims"
                 || ''0'' }}'
               openshift.io/imagestreams: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.openshift.io_imagestreams"
                 || ''20'' }}'
@@ -185,7 +187,8 @@ spec:
               persistentvolumeclaims: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.persistentvolumeclaims"
                 || ''10'' }}'
               rbd-storagepool-cluster.storageclass.storage.k8s.io/requests.storage: '{{
-                request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.rbd-storagepool-cluster.storageclass.storage.k8s.io_requests.storage"
+                parse_json(request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.storageclasses"
+                || ''{}'')."rbd-storagepool-cluster.storageclass.storage.k8s.io/requests.storage"
                 || ''25Gi'' }}'
               requests.ephemeral-storage: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.requests.ephemeral-storage"
                 || ''250Mi'' }}'

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -130,7 +130,8 @@ spec:
           spec:
             hard:
               cephfs-fspool-cluster.storageclass.storage.k8s.io/requests.storage: '{{
-                request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.cephfs-fspool-cluster.storageclass.storage.k8s.io_requests.storage"
+                parse_json(request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.storageclasses"
+                || ''{}'')."cephfs-fspool-cluster.storageclass.storage.k8s.io/requests.storage"
                 || ''25Gi'' }}'
               count/configmaps: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_configmaps"
                 || ''150'' }}'
@@ -147,7 +148,8 @@ spec:
               limits.ephemeral-storage: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.limits.ephemeral-storage"
                 || ''500Mi'' }}'
               localblock-storage.storageclass.storage.k8s.io/persistentvolumeclaims: '{{
-                request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.localblock-storage.storageclass.storage.k8s.io_persistentvolumeclaims"
+                parse_json(request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.storageclasses"
+                || ''{}'')."localblock-storage.storageclass.storage.k8s.io/persistentvolumeclaims"
                 || ''0'' }}'
               openshift.io/imagestreams: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.openshift.io_imagestreams"
                 || ''20'' }}'
@@ -156,7 +158,8 @@ spec:
               persistentvolumeclaims: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.persistentvolumeclaims"
                 || ''10'' }}'
               rbd-storagepool-cluster.storageclass.storage.k8s.io/requests.storage: '{{
-                request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.rbd-storagepool-cluster.storageclass.storage.k8s.io_requests.storage"
+                parse_json(request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.storageclasses"
+                || ''{}'')."rbd-storagepool-cluster.storageclass.storage.k8s.io/requests.storage"
                 || ''25Gi'' }}'
               requests.ephemeral-storage: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.requests.ephemeral-storage"
                 || ''250Mi'' }}'


### PR DESCRIPTION
The storageclass-specific quotas use keys which are too long to work with the generic annotation-based system for customizing the quotas in single namespaces.

This PR introduces a special annotation `resourcequota.appuio.io/<quota-name>.storageclasses` whose value is parsed as a JSON object. If there's a key which matches an existing `<storageclass>.storageclass.k8s.io` quota, the policy will use the value of that key as the final value for that quota instead of the default defined in the component defaults.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
