### PR TITLE
Deactivate default network policies in the agent namespace

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -21,7 +21,13 @@ local monitoringLabel =
 {
   '00_namespace': kube.Namespace(params.namespace) {
     metadata+: {
-      labels+: monitoringLabel,
+      labels+: monitoringLabel {
+        // Ensure the default network policies are not created in the
+        // namespace, as we need to allow access to the validating webhook
+        // from various agreggated API servers.
+        'network-policies.syn.tools/no-defaults': 'true',
+        'network-policies.syn.tools/purge-defaults': 'true',
+      },
     },
   } + common.DefaultLabels,
 }

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/00_namespace.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/00_namespace.yaml
@@ -8,4 +8,6 @@ metadata:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: appuio-cloud
     name: appuio-cloud
+    network-policies.syn.tools/no-defaults: 'true'
+    network-policies.syn.tools/purge-defaults: 'true'
   name: appuio-cloud


### PR DESCRIPTION
We deactivate the default network policies in the APPUiO Cloud agent namespace in order to ensure that various aggregated API servers (e.g. `openshift-apiserver`) can connect to the validating webhook served by the agent.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
