### PR TITLE
Update ResourceLocker cluster roles which are exempt from policies

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -43,11 +43,11 @@ parameters:
         syn-argocd-server: syn-argocd-server
         syn-resource-locker:
           # Created by openshift4-ingress
-          - syn-resource-locker-namespace-default-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
           # Created by openshift4-monitoring
-          - syn-resource-locker-namespace-openshift-monitoring-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
           # Created by openshift4-console
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
         system:controller:generic-garbage-collector: system:controller:generic-garbage-collector
         system:controller:operator-lifecycle-manager: system:controller:operator-lifecycle-manager
         system:master: system:master

--- a/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
@@ -92,9 +92,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/docs/modules/ROOT/pages/references/policies/02_organization_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_namespaces.adoc
@@ -103,9 +103,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -144,9 +144,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -186,9 +186,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/docs/modules/ROOT/pages/references/policies/02_organization_sa_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_sa_namespaces.adoc
@@ -97,9 +97,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -138,9 +138,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -185,9 +185,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/docs/modules/ROOT/pages/references/policies/02_validate_namespace_metadata.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_validate_namespace_metadata.adoc
@@ -81,9 +81,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -145,9 +145,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/docs/modules/ROOT/pages/references/policies/03_projectrequest.adoc
+++ b/docs/modules/ROOT/pages/references/policies/03_projectrequest.adoc
@@ -81,9 +81,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/docs/modules/ROOT/pages/references/policies/12_namespace_quota_per_zone.adoc
+++ b/docs/modules/ROOT/pages/references/policies/12_namespace_quota_per_zone.adoc
@@ -111,9 +111,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -177,9 +177,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
@@ -58,9 +58,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -66,9 +66,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -107,9 +107,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -149,9 +149,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_sa_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_sa_namespaces.yaml
@@ -62,9 +62,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -103,9 +103,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -150,9 +150,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
@@ -50,9 +50,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -114,9 +114,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
@@ -52,9 +52,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/12_namespace_quota_per_zone.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/12_namespace_quota_per_zone.yaml
@@ -74,9 +74,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -140,9 +140,9 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-manager
-          - syn-resource-locker-namespace-openshift-monitoring-manager
-          - syn-resource-locker-namespace-openshift-config-manager
+          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
+          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
+          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master


### PR DESCRIPTION
Adjust resource-locker clusterrole names to match the new names generated by component resource-locker v2.5.0+.

Note that the new names are stable across clusters but may change when we change the actual ResourceLocker configuration they belong to.

See also https://github.com/projectsyn/component-resource-locker/pull/51




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
