### PR TITLE
Switch to subject instead of clusterrole for resource locker

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -41,18 +41,23 @@ parameters:
         syn-admin: syn-admin
         syn-argocd-application-controller: syn-argocd-application-controller
         syn-argocd-server: syn-argocd-server
-        syn-resource-locker:
-          # Created by openshift4-ingress
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          # Created by openshift4-monitoring
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          # Created by openshift4-console
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
         system:controller:generic-garbage-collector: system:controller:generic-garbage-collector
         system:controller:operator-lifecycle-manager: system:controller:operator-lifecycle-manager
         system:master: system:master
         system:openshift:controller:namespace-security-allocation-controller: system:openshift:controller:namespace-security-allocation-controller
-      subjects: {}
+      subjects:
+        syn-resource-locker-ingress:
+          kind: ServiceAccount
+          name: namespace-default-d6a0af6dd07e8a3-manager
+          namespace: syn-resource-locker
+        syn-resource-locker-monitoring:
+          kind: ServiceAccount
+          name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+          namespace: syn-resource-locker
+        syn-resource-locker-console:
+          kind: ServiceAccount
+          name: namespace-openshift-config-2c8343f13594d63-manager
+          namespace: syn-resource-locker
 
     reservedNamespaces:
       kubernetes: ["default", "kube-*"]

--- a/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
@@ -92,9 +92,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -104,6 +101,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/docs/modules/ROOT/pages/references/policies/02_organization_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_namespaces.adoc
@@ -103,9 +103,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -115,6 +112,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -144,9 +150,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -156,6 +159,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -186,9 +198,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -198,6 +207,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/docs/modules/ROOT/pages/references/policies/02_organization_sa_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_sa_namespaces.adoc
@@ -97,9 +97,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -109,6 +106,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -138,9 +144,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -150,6 +153,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -185,9 +197,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -197,6 +206,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/docs/modules/ROOT/pages/references/policies/02_validate_namespace_metadata.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_validate_namespace_metadata.adoc
@@ -81,9 +81,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -93,6 +90,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -145,9 +151,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -157,6 +160,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/docs/modules/ROOT/pages/references/policies/03_projectrequest.adoc
+++ b/docs/modules/ROOT/pages/references/policies/03_projectrequest.adoc
@@ -81,9 +81,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -93,6 +90,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/docs/modules/ROOT/pages/references/policies/12_namespace_quota_per_zone.adoc
+++ b/docs/modules/ROOT/pages/references/policies/12_namespace_quota_per_zone.adoc
@@ -111,9 +111,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -123,6 +120,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -177,9 +183,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -189,6 +192,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
@@ -58,9 +58,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -70,6 +67,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -66,9 +66,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -78,6 +75,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -107,9 +113,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -119,6 +122,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -149,9 +161,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -161,6 +170,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_sa_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_sa_namespaces.yaml
@@ -62,9 +62,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -74,6 +71,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -103,9 +109,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -115,6 +118,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -150,9 +162,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -162,6 +171,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
@@ -50,9 +50,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -62,6 +59,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -114,9 +120,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -126,6 +129,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
@@ -52,9 +52,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -64,6 +61,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/12_namespace_quota_per_zone.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/12_namespace_quota_per_zone.yaml
@@ -74,9 +74,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -86,6 +83,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:
@@ -140,9 +146,6 @@ spec:
           - syn-admin
           - syn-argocd-application-controller
           - syn-argocd-server
-          - syn-resource-locker-namespace-default-d6a0af6dd07e8a3-manager
-          - syn-resource-locker-penshift-monitoring-c4273dc15ddfdf7-manager
-          - syn-resource-locker-ce-openshift-config-2c8343f13594d63-manager
           - system:controller:generic-garbage-collector
           - system:controller:operator-lifecycle-manager
           - system:master
@@ -152,6 +155,15 @@ spec:
           - kind: ServiceAccount
             name: argocd-application-controller
             namespace: argocd
+          - kind: ServiceAccount
+            name: namespace-openshift-config-2c8343f13594d63-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-default-d6a0af6dd07e8a3-manager
+            namespace: syn-resource-locker
+          - kind: ServiceAccount
+            name: namespace-openshift-monitoring-c4273dc15ddfdf7-manager
+            namespace: syn-resource-locker
       match:
         all:
           - resources:


### PR DESCRIPTION
By matching the clusterrole there is the potential of privilege escalation as users genrally have enough permission to give themselves the resource locker clusterrole for their own namespace.

This issue doesn't immediately exit for the other clusterroles as they all provide higher permissions than the user itself has.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
