### PR TITLE
Fix patch for disallowing docker builds

### DIFF
--- a/component/build-strategy.jsonnet
+++ b/component/build-strategy.jsonnet
@@ -10,8 +10,10 @@ local params = inv.parameters.appuio_cloud;
 local bindingToPatch = kube.ClusterRoleBinding('system:build-strategy-docker-binding');
 
 local disallowDockerBuildStrategyPatch = {
-  annotations: {
-    'rbac.authorization.kubernetes.io/autoupdate': 'false',
+  metadata: {
+    annotations: {
+      'rbac.authorization.kubernetes.io/autoupdate': 'false',
+    },
   },
   subjects: [],
 };

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -7,7 +7,7 @@ parameters:
         source: https://raw.githubusercontent.com/projectsyn/component-kyverno/v1.1.0/lib/kyverno.libsonnet
         output_path: vendor/lib/kyverno.libsonnet
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.6.0/lib/resource-locker.libjsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.6.1/lib/resource-locker.libjsonnet
         output_path: vendor/lib/resource-locker.libjsonnet
       - type: https
         source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v1.13.0/lib/openshift4-monitoring-prom.libsonnet

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -7,7 +7,7 @@ parameters:
         source: https://raw.githubusercontent.com/projectsyn/component-kyverno/v1.1.0/lib/kyverno.libsonnet
         output_path: vendor/lib/kyverno.libsonnet
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.0.1/lib/resource-locker.libjsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.6.0/lib/resource-locker.libjsonnet
         output_path: vendor/lib/resource-locker.libjsonnet
       - type: https
         source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v1.13.0/lib/openshift4-monitoring-prom.libsonnet

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/15_disallow_docker_build_strategy_patch.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/15_disallow_docker_build_strategy_patch.yaml
@@ -1,17 +1,41 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/system:build-strategy-docker-binding
   labels:
-    name: system-build-strategy-docker-binding-manager
-  name: system-build-strategy-docker-binding-manager
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: appuio-cloud
+    name: clusterrolebinding-system-build-3729a69e19ab960-manager
+  name: clusterrolebinding-system-build-3729a69e19ab960-manager
   namespace: syn-resource-locker
+secrets:
+  - name: clusterrolebinding-system-build-3729a69e19ab960-manager
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: clusterrolebinding-system-build-3729a69e19ab960-manager
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/system:build-strategy-docker-binding
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: appuio-cloud
+    name: clusterrolebinding-system-build-3729a69e19ab960-manager
+  name: clusterrolebinding-system-build-3729a69e19ab960-manager
+  namespace: syn-resource-locker
+type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/system:build-strategy-docker-binding
   labels:
-    name: syn-resource-locker-ystem-build-strategy-docker-binding-manager
-  name: syn-resource-locker-ystem-build-strategy-docker-binding-manager
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: appuio-cloud
+    name: syn-resource-locker-inding-system-build-3729a69e19ab960-manager
+  name: syn-resource-locker-inding-system-build-3729a69e19ab960-manager
 rules:
   - apiGroups:
       - rbac.authorization.k8s.io
@@ -26,16 +50,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/system:build-strategy-docker-binding
   labels:
-    name: syn-resource-locker-ystem-build-strategy-docker-binding-manager
-  name: syn-resource-locker-ystem-build-strategy-docker-binding-manager
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: appuio-cloud
+    name: syn-resource-locker-inding-system-build-3729a69e19ab960-manager
+  name: syn-resource-locker-inding-system-build-3729a69e19ab960-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: syn-resource-locker-ystem-build-strategy-docker-binding-manager
+  name: syn-resource-locker-inding-system-build-3729a69e19ab960-manager
 subjects:
   - kind: ServiceAccount
-    name: system-build-strategy-docker-binding-manager
+    name: clusterrolebinding-system-build-3729a69e19ab960-manager
     namespace: syn-resource-locker
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1
@@ -44,13 +72,13 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
-    name: system-build-strategy-docker-binding
-  name: system-build-strategy-docker-binding
+    name: clusterrolebinding-system-build-3729a69e19ab960
+  name: clusterrolebinding-system-build-3729a69e19ab960
   namespace: syn-resource-locker
 spec:
   patches:
     - id: patch1
-      patchTemplate: "\"annotations\":\n  \"rbac.authorization.kubernetes.io/autoupdate\"\
+      patchTemplate: "\"metadata\":\n  \"annotations\":\n    \"rbac.authorization.kubernetes.io/autoupdate\"\
         : \"false\"\n\"subjects\": []"
       patchType: application/strategic-merge-patch+json
       targetObjectRef:
@@ -58,4 +86,4 @@ spec:
         kind: ClusterRoleBinding
         name: system:build-strategy-docker-binding
   serviceAccountRef:
-    name: system-build-strategy-docker-binding-manager
+    name: clusterrolebinding-system-build-3729a69e19ab960-manager

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/15_disallow_docker_build_strategy_patch.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/15_disallow_docker_build_strategy_patch.yaml
@@ -30,6 +30,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    resourcelocker.syn.tools/cluster-admin: This resource-locker clusterrole grants
+      cluster-admin because it's otherwise impossible to manage clusterrolebindings
+      with unknown role references
     resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/system:build-strategy-docker-binding
   labels:
     app.kubernetes.io/managed-by: commodore
@@ -38,14 +41,11 @@ metadata:
   name: syn-resource-locker-inding-system-build-3729a69e19ab960-manager
 rules:
   - apiGroups:
-      - rbac.authorization.k8s.io
+      - '*'
     resources:
-      - clusterrolebindings
+      - '*'
     verbs:
-      - get
-      - list
-      - patch
-      - watch
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
To overwrite the `rbac.authorization.kubernetes.io/autoupdate` annotation we need to patch `metadata.annotations`, not `annotations`.

The fixed patch also needs https://github.com/projectsyn/component-resource-locker/pull/63, otherwise it won't apply on the cluster.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
