### PR TITLE
Add support for SSH URL to the policy doc generator

### DIFF
--- a/tools/render/git.go
+++ b/tools/render/git.go
@@ -15,6 +15,15 @@ import (
 )
 
 func newGitInfo(rawurl string) (*gitInfo, error) {
+
+	if strings.HasPrefix(rawurl, "git@") {
+		hostPath := strings.Split(strings.TrimPrefix(rawurl, "git@"), ":")
+		if len(hostPath) != 2 {
+			return nil, fmt.Errorf("failed to parse SSH URL %q", rawurl)
+		}
+		rawurl = fmt.Sprintf("https://%s/%s", hostPath[0], hostPath[1])
+	}
+
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL %s: %v", rawurl, err)


### PR DESCRIPTION
A bit hacky but this should now allow to run the policy doc generate tool if you cloned the repo using the SSH URL.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
