### PR TITLE
Make APPUiO Cloud Agent resource requests and limits configurable

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -14,6 +14,10 @@ parameters:
 
     agent:
       replicas: 3
+      # Customize agent deployment resource requests & limits
+      resources:
+        limits:
+          memory: 1Gi
       resourceRatio:
         memoryPerCore: 4Gi
       webhook:

--- a/component/agent.jsonnet
+++ b/component/agent.jsonnet
@@ -105,6 +105,7 @@ local deployment = loadManifest('manager/manager.yaml') {
               args+: [
                 '--webhook-cert-dir=' + webhookCertDir,
               ],
+              resources+: com.makeMergeable(params.agent.resources),
               volumeMounts+: [
                 {
                   name: 'webhook-service-tls',

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -36,6 +36,22 @@ default:: 3
 With how many replicas the APPUiO Cloud Agent should run.
 
 
+== `agent.resources`
+
+[horizontal]
+type:: dict
+default::
++
+[source,yaml]
+----
+limits:
+  memory: 1Gi
+----
+
+Resource requests and limits for the APPUiO Cloud Agent deployment.
+
+The contents of this parameter are merged over the default resource requests and limits of the Agent's base configuration.
+
 == `agent.resourceRatio.memoryPerCore`
 type:: string
 default:: `4Gi`

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
@@ -45,7 +45,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 256Mi
+              memory: 1Gi
             requests:
               cpu: 10m
               memory: 128Mi


### PR DESCRIPTION
Also set default memory limit to 1Gi (up from 256Mi), since we've seen the new agent pods which also observe namespaces crashlooping on zones which have more than a handful of namespaces.

Follow-up for #129 


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
