### PR TITLE
Add clusterrole appuio:metrics-viewer

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -55,6 +55,12 @@ parameters:
               - edit
               - patch
               - delete
+      appuio:metrics-reader:
+        rules:
+          - apiGroups: ['']
+            resources: [pods]
+            verbs:
+              - get
 
     bypassNamespaceRestrictions:
       # Roles are not supported for the APPUiO Cloud Agent. Should be left empty.

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_additional_clusterroles.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_additional_clusterroles.yaml
@@ -6,6 +6,24 @@ metadata:
     app.kubernetes.io/component: appuio-cloud
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: appuio-cloud
+    name: appuio-metrics-reader
+  name: appuio:metrics-reader
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: appuio-cloud
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud
     name: namespace-owner
   name: namespace-owner
 rules:


### PR DESCRIPTION
This clusterrole can be used to delegate access to the user-workload monitoring metrics. By binding this clusterrole in a namespace it gives the subjects access to all metrics in that namespace




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
