### PR TITLE
Add `count/jobs.batch` quota of 150 to `organization-objects` resourcequota

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -146,6 +146,7 @@ parameters:
         spec:
           hard:
             count/configmaps: "150"
+            count/jobs.batch: "150"
             count/secrets: "150"
             count/services: "20"
             count/services.loadbalancers: "0"

--- a/docs/modules/ROOT/pages/references/policies/11_generate_quota_limit_range_in_ns.adoc
+++ b/docs/modules/ROOT/pages/references/policies/11_generate_quota_limit_range_in_ns.adoc
@@ -164,6 +164,8 @@ spec:
                 || ''25Gi'' }}'
               count/configmaps: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_configmaps"
                 || ''150'' }}'
+              count/jobs.batch: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_jobs.batch"
+                || ''150'' }}'
               count/replicationcontrollers: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_replicationcontrollers"
                 || ''100'' }}'
               count/secrets: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_secrets"

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/11_generate_quota_limit_range_in_ns.yaml
@@ -135,6 +135,8 @@ spec:
                 || ''25Gi'' }}'
               count/configmaps: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_configmaps"
                 || ''150'' }}'
+              count/jobs.batch: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_jobs.batch"
+                || ''150'' }}'
               count/replicationcontrollers: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_replicationcontrollers"
                 || ''100'' }}'
               count/secrets: '{{ request.object.metadata.annotations."resourcequota.appuio.io/organization-objects.count_secrets"


### PR DESCRIPTION
We've observed that large amounts of completed jobs (and associated pods) can cause increased resource consumption in control plane components (e.g. apiserver memory usage). We've also observed noticeable `kubectl` lag for operations like `kubectl get pods -A`.

We've picked an initial limit of 150 jobs which should be sufficient for regular uses (e.g. appuio-cloud-reporting currently has 57 jobs in the namespace).


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
