### PR TITLE
Add PSA namespace label syncer clusterrole to bypass clusterroles

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -92,6 +92,7 @@ parameters:
         system:controller:operator-lifecycle-manager: system:controller:operator-lifecycle-manager
         system:master: system:master
         system:openshift:controller:namespace-security-allocation-controller: system:openshift:controller:namespace-security-allocation-controller
+        system:openshift:controller:podsecurity-admission-label-syncer-controller: system:openshift:controller:podsecurity-admission-label-syncer-controller
       subjects:
         syn-resource-locker-ingress:
           kind: ServiceAccount

--- a/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
@@ -97,6 +97,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/docs/modules/ROOT/pages/references/policies/02_organization_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_namespaces.adoc
@@ -108,6 +108,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -156,6 +157,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -204,6 +206,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/docs/modules/ROOT/pages/references/policies/02_organization_sa_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_sa_namespaces.adoc
@@ -102,6 +102,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -150,6 +151,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -203,6 +205,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/docs/modules/ROOT/pages/references/policies/02_validate_namespace_metadata.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_validate_namespace_metadata.adoc
@@ -86,6 +86,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -156,6 +157,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/docs/modules/ROOT/pages/references/policies/03_projectrequest.adoc
+++ b/docs/modules/ROOT/pages/references/policies/03_projectrequest.adoc
@@ -86,6 +86,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/docs/modules/ROOT/pages/references/policies/12_namespace_quota_per_zone.adoc
+++ b/docs/modules/ROOT/pages/references/policies/12_namespace_quota_per_zone.adoc
@@ -116,6 +116,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -189,6 +190,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_config_map.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_config_map.yaml
@@ -9,8 +9,8 @@ data:
     \n- \"openshift-dns-operator\"\n- \"openshift-ingress-operator\"\n- \"syn-admin\"\
     \n- \"syn-argocd-application-controller\"\n- \"syn-argocd-server\"\n- \"system:controller:generic-garbage-collector\"\
     \n- \"system:controller:operator-lifecycle-manager\"\n- \"system:master\"\n- \"\
-    system:openshift:controller:namespace-security-allocation-controller\"\n\"PrivilegedGroups\"\
-    : []\n\"PrivilegedUsers\":\n- \"system:serviceaccount:argocd:argocd-application-controller\"\
+    system:openshift:controller:namespace-security-allocation-controller\"\n- \"system:openshift:controller:podsecurity-admission-label-syncer-controller\"\
+    \n\"PrivilegedGroups\": []\n\"PrivilegedUsers\":\n- \"system:serviceaccount:argocd:argocd-application-controller\"\
     \n- \"system:serviceaccount:syn-resource-locker:namespace-openshift-config-2c8343f13594d63-manager\"\
     \n- \"system:serviceaccount:syn-resource-locker:namespace-default-d6a0af6dd07e8a3-manager\"\
     \n- \"system:serviceaccount:syn-resource-locker:namespace-openshift-monitoring-c4273dc15ddfdf7-manager\""

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 24c254d2b0975db456744bd7f2f49a53
+        checksum/config: a1d896d928f0c283d0841f0290a4443d
         kubectl.kubernetes.io/default-container: agent
       labels:
         control-plane: appuio-cloud-agent

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
@@ -63,6 +63,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -71,6 +71,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -119,6 +120,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -167,6 +169,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_sa_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_sa_namespaces.yaml
@@ -67,6 +67,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -115,6 +116,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -168,6 +170,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
@@ -55,6 +55,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -125,6 +126,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
@@ -57,6 +57,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/12_namespace_quota_per_zone.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/12_namespace_quota_per_zone.yaml
@@ -79,6 +79,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller
@@ -152,6 +153,7 @@ spec:
               - system:controller:operator-lifecycle-manager
               - system:master
               - system:openshift:controller:namespace-security-allocation-controller
+              - system:openshift:controller:podsecurity-admission-label-syncer-controller
           - subjects:
               - kind: ServiceAccount
                 name: argocd-application-controller


### PR DESCRIPTION
On OpenShift 4.11 the `podsecurity-admission-label-syncer-controller` needs to modify namespace labels to ensure the namespace's PSA labels match the most privileged SCC that can be used in the namespace, cf. https://docs.appuio.cloud/user/explanation/pod-security-admissions.html




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
