### PR TITLE
Allow OLM operator to bypass NS restrictions

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -106,6 +106,10 @@ parameters:
           kind: ServiceAccount
           name: namespace-openshift-config-2c8343f13594d63-manager
           namespace: syn-resource-locker
+        openshift-operator-lifecycle-manager:
+          kind: ServiceAccount
+          name: olm-operator-serviceaccount
+          namespace: openshift-operator-lifecycle-manager
 
     reservedNamespaces:
       kubernetes: ["default", "kube-*"]

--- a/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_disallow_reserved_namespaces.adoc
@@ -103,6 +103,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount

--- a/docs/modules/ROOT/pages/references/policies/02_organization_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_namespaces.adoc
@@ -114,6 +114,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount
@@ -163,6 +166,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount
@@ -211,6 +217,9 @@ spec:
               - kind: ServiceAccount
                 name: argocd-application-controller
                 namespace: argocd
+              - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
               - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker

--- a/docs/modules/ROOT/pages/references/policies/02_organization_sa_namespaces.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_organization_sa_namespaces.adoc
@@ -108,6 +108,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount
@@ -156,6 +159,9 @@ spec:
               - kind: ServiceAccount
                 name: argocd-application-controller
                 namespace: argocd
+              - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
               - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
@@ -210,6 +216,9 @@ spec:
               - kind: ServiceAccount
                 name: argocd-application-controller
                 namespace: argocd
+              - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
               - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker

--- a/docs/modules/ROOT/pages/references/policies/02_validate_namespace_metadata.adoc
+++ b/docs/modules/ROOT/pages/references/policies/02_validate_namespace_metadata.adoc
@@ -92,6 +92,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount
@@ -162,6 +165,9 @@ spec:
               - kind: ServiceAccount
                 name: argocd-application-controller
                 namespace: argocd
+              - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
               - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker

--- a/docs/modules/ROOT/pages/references/policies/03_projectrequest.adoc
+++ b/docs/modules/ROOT/pages/references/policies/03_projectrequest.adoc
@@ -92,6 +92,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount

--- a/docs/modules/ROOT/pages/references/policies/12_namespace_quota_per_zone.adoc
+++ b/docs/modules/ROOT/pages/references/policies/12_namespace_quota_per_zone.adoc
@@ -122,6 +122,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount
@@ -195,6 +198,9 @@ spec:
               - kind: ServiceAccount
                 name: argocd-application-controller
                 namespace: argocd
+              - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
               - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_config_map.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_config_map.yaml
@@ -11,6 +11,7 @@ data:
     \n- \"system:controller:operator-lifecycle-manager\"\n- \"system:master\"\n- \"\
     system:openshift:controller:namespace-security-allocation-controller\"\n- \"system:openshift:controller:podsecurity-admission-label-syncer-controller\"\
     \n\"PrivilegedGroups\": []\n\"PrivilegedUsers\":\n- \"system:serviceaccount:argocd:argocd-application-controller\"\
+    \n- \"system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount\"\
     \n- \"system:serviceaccount:syn-resource-locker:namespace-openshift-config-2c8343f13594d63-manager\"\
     \n- \"system:serviceaccount:syn-resource-locker:namespace-default-d6a0af6dd07e8a3-manager\"\
     \n- \"system:serviceaccount:syn-resource-locker:namespace-openshift-monitoring-c4273dc15ddfdf7-manager\""

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a1d896d928f0c283d0841f0290a4443d
+        checksum/config: 98737c1e624c2d57494fc0cfdbe029b9
         kubectl.kubernetes.io/default-container: agent
       labels:
         control-plane: appuio-cloud-agent

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_disallow_reserved_namespaces.yaml
@@ -69,6 +69,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_namespaces.yaml
@@ -77,6 +77,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount
@@ -126,6 +129,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount
@@ -174,6 +180,9 @@ spec:
               - kind: ServiceAccount
                 name: argocd-application-controller
                 namespace: argocd
+              - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
               - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_sa_namespaces.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_organization_sa_namespaces.yaml
@@ -73,6 +73,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount
@@ -121,6 +124,9 @@ spec:
               - kind: ServiceAccount
                 name: argocd-application-controller
                 namespace: argocd
+              - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
               - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
@@ -175,6 +181,9 @@ spec:
               - kind: ServiceAccount
                 name: argocd-application-controller
                 namespace: argocd
+              - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
               - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/02_validate_namespace_metadata.yaml
@@ -61,6 +61,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount
@@ -131,6 +134,9 @@ spec:
               - kind: ServiceAccount
                 name: argocd-application-controller
                 namespace: argocd
+              - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
               - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/03_projectrequest.yaml
@@ -63,6 +63,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/12_namespace_quota_per_zone.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/12_namespace_quota_per_zone.yaml
@@ -85,6 +85,9 @@ spec:
                 name: argocd-application-controller
                 namespace: argocd
               - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
+              - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker
               - kind: ServiceAccount
@@ -158,6 +161,9 @@ spec:
               - kind: ServiceAccount
                 name: argocd-application-controller
                 namespace: argocd
+              - kind: ServiceAccount
+                name: olm-operator-serviceaccount
+                namespace: openshift-operator-lifecycle-manager
               - kind: ServiceAccount
                 name: namespace-openshift-config-2c8343f13594d63-manager
                 namespace: syn-resource-locker


### PR DESCRIPTION
OLM operator seems to be desparate to update the namespaces: https://github.com/appuio/component-appuio-cloud/issues/76#issuecomment-1335185729

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
