### PR TITLE
Configure access to user workload monitoring in the component defaults

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -52,6 +52,7 @@ parameters:
           namespace-owner: namespace-owner
           monitoring-edit: monitoring-edit
           alert-routing-edit: alert-routing-edit
+          monitoring-edit-probe: monitoring-edit-probe
 
     clusterRoles:
       namespace-owner:
@@ -70,6 +71,13 @@ parameters:
             resources: [pods]
             verbs:
               - get
+      monitoring-edit-probe:
+        rules:
+          - apiGroups: ['monitoring.coreos.com']
+            resources:
+              - probes
+            verbs:
+              - '*'
 
     bypassNamespaceRestrictions:
       # Roles are not supported for the APPUiO Cloud Agent. Should be left empty.

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -50,6 +50,8 @@ parameters:
         DefaultOrganizationClusterRoles:
           admin: admin
           namespace-owner: namespace-owner
+          monitoring-edit: monitoring-edit
+          alert-routing-edit: alert-routing-edit
 
     clusterRoles:
       namespace-owner:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_config_map.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_config_map.yaml
@@ -3,8 +3,9 @@ data:
   config.yaml: "\"DefaultNamespaceNodeSelectorAnnotation\": \"appuio.io/default-node-selector\"\
     \n\"DefaultNodeSelector\": {}\n\"DefaultOrganizationClusterRoles\":\n  \"admin\"\
     : \"admin\"\n  \"alert-routing-edit\": \"alert-routing-edit\"\n  \"monitoring-edit\"\
-    : \"monitoring-edit\"\n  \"namespace-owner\": \"namespace-owner\"\n\"MemoryPerCoreLimit\"\
-    : \"4Gi\"\n\"OrganizationLabel\": \"appuio.io/organization\"\n\"PrivilegedClusterRoles\"\
+    : \"monitoring-edit\"\n  \"monitoring-edit-probe\": \"monitoring-edit-probe\"\n\
+    \  \"namespace-owner\": \"namespace-owner\"\n\"MemoryPerCoreLimit\": \"4Gi\"\n\
+    \"OrganizationLabel\": \"appuio.io/organization\"\n\"PrivilegedClusterRoles\"\
     :\n- \"cluster-admin\"\n- \"cluster-image-registry-operator\"\n- \"cluster-node-tuning-operator\"\
     \n- \"kyverno:generatecontroller\"\n- \"kyverno:policycontroller\"\n- \"multus-admission-controller-webhook\"\
     \n- \"openshift-dns-operator\"\n- \"openshift-ingress-operator\"\n- \"syn-admin\"\

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_config_map.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_config_map.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 data:
   config.yaml: "\"DefaultNamespaceNodeSelectorAnnotation\": \"appuio.io/default-node-selector\"\
     \n\"DefaultNodeSelector\": {}\n\"DefaultOrganizationClusterRoles\":\n  \"admin\"\
-    : \"admin\"\n  \"namespace-owner\": \"namespace-owner\"\n\"MemoryPerCoreLimit\"\
+    : \"admin\"\n  \"alert-routing-edit\": \"alert-routing-edit\"\n  \"monitoring-edit\"\
+    : \"monitoring-edit\"\n  \"namespace-owner\": \"namespace-owner\"\n\"MemoryPerCoreLimit\"\
     : \"4Gi\"\n\"OrganizationLabel\": \"appuio.io/organization\"\n\"PrivilegedClusterRoles\"\
     :\n- \"cluster-admin\"\n- \"cluster-image-registry-operator\"\n- \"cluster-node-tuning-operator\"\
     \n- \"kyverno:generatecontroller\"\n- \"kyverno:policycontroller\"\n- \"multus-admission-controller-webhook\"\

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_default_org_role_binding.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_default_org_role_binding.yaml
@@ -51,6 +51,22 @@ kind: ClusterRoleBinding
 metadata:
   annotations: {}
   labels:
+    name: appuio-cloud-agent-monitoring-edit-probe
+  name: appuio-cloud-agent:monitoring-edit-probe
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monitoring-edit-probe
+subjects:
+  - kind: ServiceAccount
+    name: appuio-cloud-agent
+    namespace: appuio-cloud
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
     name: appuio-cloud-agent-namespace-owner
   name: appuio-cloud-agent:namespace-owner
 roleRef:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_default_org_role_binding.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_default_org_role_binding.yaml
@@ -19,6 +19,38 @@ kind: ClusterRoleBinding
 metadata:
   annotations: {}
   labels:
+    name: appuio-cloud-agent-alert-routing-edit
+  name: appuio-cloud-agent:alert-routing-edit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alert-routing-edit
+subjects:
+  - kind: ServiceAccount
+    name: appuio-cloud-agent
+    namespace: appuio-cloud
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-cloud-agent-monitoring-edit
+  name: appuio-cloud-agent:monitoring-edit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monitoring-edit
+subjects:
+  - kind: ServiceAccount
+    name: appuio-cloud-agent
+    namespace: appuio-cloud
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
     name: appuio-cloud-agent-namespace-owner
   name: appuio-cloud-agent:namespace-owner
 roleRef:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b1f9b327b7b8cf0a06958af73263bc62
+        checksum/config: f4afb0b2c6f9b91a2018c3793acdb071
         kubectl.kubernetes.io/default-container: agent
       labels:
         control-plane: appuio-cloud-agent

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f4afb0b2c6f9b91a2018c3793acdb071
+        checksum/config: 46520032520e499aa0d8586682fce813
         kubectl.kubernetes.io/default-container: agent
       labels:
         control-plane: appuio-cloud-agent

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/10_additional_clusterroles.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/10_additional_clusterroles.yaml
@@ -24,6 +24,24 @@ metadata:
     app.kubernetes.io/component: appuio-cloud
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: appuio-cloud
+    name: monitoring-edit-probe
+  name: monitoring-edit-probe
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - probes
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: appuio-cloud
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: appuio-cloud
     name: namespace-owner
   name: namespace-owner
 rules:


### PR DESCRIPTION
This PR adds role bindings for the `monitoring-edit` and `alert-routing-edit` cluster roles to the default role bindings created in each organization namespace.

Additionally, the PR adds a cluster role `monitoring-edit-probe`, and an associated default role binding. This additional cluster role is necessary because the upstream `monitoring-edit` cluster role doesn't grant edit permissions for the `Probe` custom resource.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
