### PR TITLE
Allow removing appuio-cloud-agent config entries by setting them to `null`

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -245,6 +245,7 @@ default:: https://github.com/appuio/component-appuio-cloud/blob/master/class/def
 This parameter allows configuring the APPUiO Cloud Agent.
 See the https://github.com/appuio/appuio-cloud-agent/blob/HEAD/config.go[Agent repository] for an overview of the available configuration options.
 
+Configuration parameters can be removed in the hierarchy by setting them to `null`.
 
 ==== `agent.config._subjects`
 


### PR DESCRIPTION

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
