### PR TITLE
Remove unnecessary organization role binding `cluster-logging-application-view`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -72,7 +72,6 @@ parameters:
           alert-routing-edit: alert-routing-edit
           monitoring-edit-probe: monitoring-edit-probe
           resource-quota-edit: resource-quota-edit
-          cluster-logging-application-view: cluster-logging-application-view
 
         LegacyNamespaceQuota: ${appuio_cloud:maxNamespaceQuota}
 

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_config_map.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_config_map.yaml
@@ -21,7 +21,6 @@ data:
     "DefaultOrganizationClusterRoles":
       "admin": "admin"
       "alert-routing-edit": "alert-routing-edit"
-      "cluster-logging-application-view": "cluster-logging-application-view"
       "monitoring-edit": "monitoring-edit"
       "monitoring-edit-probe": "monitoring-edit-probe"
       "namespace-owner": "namespace-owner"

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_default_org_role_binding.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/01_default_org_role_binding.yaml
@@ -35,22 +35,6 @@ kind: ClusterRoleBinding
 metadata:
   annotations: {}
   labels:
-    name: appuio-cloud-agent-cluster-logging-application-view
-  name: appuio-cloud-agent:cluster-logging-application-view
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-logging-application-view
-subjects:
-  - kind: ServiceAccount
-    name: appuio-cloud-agent
-    namespace: appuio-cloud
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  annotations: {}
-  labels:
     name: appuio-cloud-agent-monitoring-edit
   name: appuio-cloud-agent:monitoring-edit
 roleRef:

--- a/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
+++ b/tests/golden/defaults/appuio-cloud/appuio-cloud/01_agent/02_deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e54a385a1e2f485fb551eff97db717a3
+        checksum/config: 23ac239163c7dcc887ded3396424bde6
         kubectl.kubernetes.io/default-container: agent
       labels:
         control-plane: appuio-cloud-agent


### PR DESCRIPTION
The same permissions are part of the `admin` cluster role, so we don't need to setup an explicit organization role binding for the `cluster-logging-application-view` cluster role.

Reverts #216 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
